### PR TITLE
Split grunt copy task into copy and uglify to minify JS files

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -43,6 +43,42 @@ module.exports = function (grunt) {
                 }]
             }
         },
+        uglify: {
+            options: {
+                mangle: false,
+                compress: false
+            },
+            dist: {
+                files: [{
+                    expand: true,
+                    cwd: 'src/',
+                    src: [
+                        /* static files */
+                        'nls/{,*/}*.js',
+                        'xorigin.js',
+                        'dependencies.js',
+                        'thirdparty/requirejs/require.js',
+                        'LiveDevelopment/MultiBrowserImpl/transports/**/*.js',
+                        'LiveDevelopment/MultiBrowserImpl/launchers/**/*.js',
+
+                        /* extensions and CodeMirror modes */
+                        '!extensions/default/*/unittests.js',
+                        'extensions/default/*/**/*.js',
+                        '!**/unittest-files/**',
+                        '!extensions/default/JavaScriptCodeHints/thirdparty/*/test/**/*',
+                        '!extensions/default/**/node_modules/**/*',
+                        'thirdparty/CodeMirror2/addon/{,*/}*.js',
+                        'thirdparty/CodeMirror2/keymap/{,*/}*.js',
+                        'thirdparty/CodeMirror2/lib/{,*/}*.js',
+                        'thirdparty/CodeMirror2/mode/{,*/}*.js',
+                        'thirdparty/CodeMirror2/theme/{,*/}*.js',
+                        'thirdparty/i18n/*.js',
+                        'thirdparty/text/*.js'
+                    ],
+                    dest: 'dist/'
+                }]
+            }
+        },
         copy: {
             dist: {
                 files: [
@@ -64,7 +100,18 @@ module.exports = function (grunt) {
                             'LiveDevelopment/MultiBrowserImpl/launchers/**'
                         ]
                     },
-
+                    /* node domains are not minified and must be copied to dist */
+                    {
+                        expand: true,
+                        dest: 'dist/',
+                        cwd: 'src/',
+                        src: [
+                            'extensibility/node/**',
+                            '!extensibility/node/spec/**',
+                            'filesystem/impls/appshell/node/**',
+                            '!filesystem/impls/appshell/node/spec/**'
+                        ]
+                    },
                     /* extensions and CodeMirror modes */
                     {
                         expand: true,
@@ -327,6 +374,9 @@ module.exports = function (grunt) {
         'usemin',
         'build-config'
     ]);
+
+    // task: build dist/ for browser
+    grunt.registerTask('build-browser', ['build', 'uglify']);
 
     // Default task.
     grunt.registerTask('default', ['test']);

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
         "grunt-contrib-htmlmin": "0.1.3",
         "grunt-contrib-less": "0.8.2",
         "grunt-contrib-requirejs": "0.4.1",
-        "grunt-contrib-uglify": "0.2.0",
+        "grunt-contrib-uglify": "0.8.0",
         "grunt-contrib-concat": "0.3.0",
         "grunt-targethtml": "0.2.6",
         "grunt-usemin": "0.1.11",


### PR DESCRIPTION
Previously, the grunt build was just copying things from the source tree, which left a lot of JS unminified (i.e., anything in an extension or not in the requirejs build step).  This splits the copy process across two tasks, one of which copies, then the second uglfiies things in dist.

I had to do one hack I don't love, but I'm not sure how to fix it.  The code for the QuickView extension's main.js breaks when you minify it.  I could try and track that down, but it won't save enough space to worry about, so I just skip it (i.e., copy but don't minify).