### PR TITLE
Stop loading SourceCodePro-Medium via JS and change font to look nicer

### DIFF
--- a/src/styles/brackets_fonts.less
+++ b/src/styles/brackets_fonts.less
@@ -83,4 +83,4 @@
 @sansFontFamily: Helvetica, Arial, "Meiryo UI", "ＭＳ Ｐゴシック", "MS PGothic", sans-serif;
 
 @sourceFontFamily: "Menlo Regular", Consolas, Inconsolata, "Vera Sans", "Lucida Console", Courier, fixed;
-@sourceFontFamily-Medium: "ＭＳ ゴシック", "MS Gothic", monospace;
+@sourceFontFamily-Medium: "Menlo Regular", Consolas, Inconsolata, "Vera Sans", "Lucida Console", Courier, fixed;

--- a/src/view/ViewCommandHandlers.js
+++ b/src/view/ViewCommandHandlers.js
@@ -91,7 +91,7 @@ define(function (require, exports, module) {
      * The default font family
      * @type {string}
      */
-    var DEFAULT_FONT_FAMILY = "'SourceCodePro-Medium', ＭＳ ゴシック, 'MS Gothic', monospace";
+    var DEFAULT_FONT_FAMILY = "'Menlo Regular', Consolas, Inconsolata, 'Vera Sans', 'Lucida Console', Courier, fixed";
 
     /**
      * @private


### PR DESCRIPTION
We had one more spot where we loaded the SourceCodePro-Medium font, this time via JS.  I've fixed that, and also changed the font we use, since it really looks horrible with their default.