### PR TITLE
Fix #178 - Add an autoprefixer to the grunt-less task

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -33,6 +33,8 @@ var GIT_REMOTE = env.get("BRAMBLE_MAIN_REMOTE") || "upstream";
 module.exports = function (grunt) {
     'use strict';
 
+    var autoprefixer = require('autoprefixer-core');
+
     // load dependencies
     require('load-grunt-tasks')(grunt, {pattern: ['grunt-contrib-*', 'grunt-targethtml', 'grunt-usemin', 'grunt-cleanempty', 'grunt-npm', 'grunt-git', 'grunt-update-submodules']});
     grunt.loadTasks('tasks');
@@ -165,6 +167,24 @@ module.exports = function (grunt) {
                     compress: true
                 }
             }
+        },
+        postcss: {
+            options: {
+                processors: [
+                    autoprefixer({
+                        browsers: [
+                            "Explorer >= 10",
+                            "Firefox >= 26",
+                            "Chrome >= 31",
+                            "Safari >= 7",
+                            "Opera >= 19",
+                            "iOS >= 3.2",
+                            "Android >= 4.4"
+                        ]
+                    }).postcss
+                ]
+            },
+            dist: { src: 'src/styles/brackets.min.css' }
         },
         requirejs: {
             dist: {
@@ -428,6 +448,9 @@ module.exports = function (grunt) {
             }
         }
     });
+    
+    // Load postcss
+    grunt.loadNpmTasks('grunt-postcss');
 
     // Bramble-task: smartCheckout
     //   Checks out to the branch provided as a target.
@@ -493,6 +516,7 @@ module.exports = function (grunt) {
         'jasmine',
         'clean',
         'less',
+        'postcss',
         'targethtml',
         'useminPrepare',
         'htmlmin',

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
         "SHA": ""
     },
     "dependencies": {
-        "grunt": "0.4.1",
+        "autoprefixer-core": "5.1.8",
+        "grunt": "0.4.5",
         "grunt-cli": "0.1.9",
         "grunt-contrib-clean": "0.4.1",
         "grunt-contrib-concat": "0.3.0",
@@ -23,6 +24,7 @@
         "grunt-contrib-jasmine": "0.4.2",
         "grunt-contrib-jshint": "0.6.0",
         "grunt-contrib-less": "0.8.2",
+        "grunt-postcss": "0.3.0",
         "grunt-contrib-requirejs": "0.4.1",
         "grunt-contrib-uglify": "0.2.0",
         "grunt-contrib-watch": "0.4.3",


### PR DESCRIPTION
Fix #178 