### PR TITLE
Updated to revoke stale URL objects

### DIFF
--- a/src/filesystem/impls/filer/FilerFileSystem.js
+++ b/src/filesystem/impls/filer/FilerFileSystem.js
@@ -9,7 +9,8 @@ define(function (require, exports, module) {
         Filer           = require("filesystem/impls/filer/BracketsFiler"),
         Dialog          = require("thirdparty/filer-dialogs/filer-dialogs"),
         BlobUtils       = require("filesystem/impls/filer/BlobUtils"),
-        Content         = require("filesystem/impls/filer/lib/content");
+        Content         = require("filesystem/impls/filer/lib/content"),
+        Handlers        = require("filesystem/impls/filer/lib/handlers");
 
     var fs              = Filer.fs(),
         Path            = Filer.Path,
@@ -231,7 +232,7 @@ define(function (require, exports, module) {
                 // Add a BLOB cache record for this filename
                 // only if it's not an HTML file
                 if(!Content.isHTML(Path.extname(path))) {
-                    BlobUtils.cache(path, data);
+                    Handlers.handleFile(path, data);
                 }
 
                 stat(path, function (err, stat) {

--- a/src/filesystem/impls/filer/lib/content.js
+++ b/src/filesystem/impls/filer/lib/content.js
@@ -1,5 +1,5 @@
 /*jslint vars: true, plusplus: true, devel: true, nomen: true, regexp: true, indent: 4, maxerr: 50 */
-/*global define, Blob, URL */
+/*global define */
 define(function (require, exports, module) {
     "use strict";
 
@@ -107,11 +107,6 @@ define(function (require, exports, module) {
             }
 
             return !(/\:?\/\//.test(url) || /\s*data\:/.test(url));
-        },
-
-        toURL: function(data, type) {
-            var blob = new Blob([data], {type: type});
-            return URL.createObjectURL(blob);
         }
     };
 });

--- a/src/filesystem/impls/filer/lib/handlers.js
+++ b/src/filesystem/impls/filer/lib/handlers.js
@@ -7,6 +7,7 @@ define(function (require, exports, module) {
     var HTMLRewriter = require("filesystem/impls/filer/lib/HTMLRewriter");
     var CSSRewriter = require("filesystem/impls/filer/lib/CSSRewriter");
     var Path  = require("filesystem/impls/filer/BracketsFiler").Path;
+    var BlobUtils = require("filesystem/impls/filer/BlobUtils");
 
     /**
      * Send the raw file, making it somewhat more readable
@@ -23,7 +24,7 @@ define(function (require, exports, module) {
             data = CSSRewriter.rewrite(path, data.toString());
         }
 
-        return Content.toURL(data, mimeType);
+        return BlobUtils.createURL(path, data, mimeType);
     }
 
     exports.handleFile = handleFile;


### PR DESCRIPTION
Fixes #162. This patch caches new URL Objects when they are created. The cache function automatically deals with revoking/removing previous URLs. Should be landed together with [this] (https://github.com/humphd/brackets-browser-livedev/pull/58).