### PR TITLE
Fixes live preview on CSS save

### DIFF
--- a/src/filesystem/impls/filer/FilerFileSystem.js
+++ b/src/filesystem/impls/filer/FilerFileSystem.js
@@ -16,6 +16,8 @@ define(function (require, exports, module) {
         Path            = Filer.Path,
         watchers        = {};
 
+    var LiveDevMultiBrowser = brackets.getModule("LiveDevelopment/LiveDevMultiBrowser");
+
     var _changeCallback;            // Callback to notify FileSystem of watcher changes
 
     function showOpenDialog(allowMultipleSelection, chooseDirectories, title, initialPath, fileTypes, callback) {
@@ -233,6 +235,8 @@ define(function (require, exports, module) {
                 // only if it's not an HTML file
                 if(!Content.isHTML(Path.extname(path))) {
                     Handlers.handleFile(path, data);
+                    // Reload the live preview when CSS is cached
+                    LiveDevMultiBrowser.reload();
                 }
 
                 stat(path, function (err, stat) {


### PR DESCRIPTION
Fixes #175. This patch fixes the issue where the live preview doesn't reflect the changes made to a CSS file after it has been saved. The patch reloads the live preview, after a CSS has been saved, updating the live preview with the new Blob URL of the saved CSS.