### PR TITLE
Add JavaScriptCodeHints and SVGCodeHints to list of default extensions

### DIFF
--- a/src/utils/ExtensionLoader.js
+++ b/src/utils/ExtensionLoader.js
@@ -398,6 +398,8 @@ define(function (require, exports, module) {
                     // Core extensions we want to support in the browser
                     "CSSCodeHints",
                     "HTMLCodeHints",
+                    "JavaScriptCodeHints",
+                    "SVGCodeHints",
                     "HtmlEntityCodeHints",
                     "InlineColorEditor",
                     "JavaScriptQuickEdit",


### PR DESCRIPTION
I just noticed we're missing the code hint extensions for JS and SVG.  This adds them in.