### PR TITLE
Fix #208 - Remove Haskell from src/language/languages.json

### DIFF
--- a/src/language/languages.json
+++ b/src/language/languages.json
@@ -71,13 +71,5 @@
             "swf", "tar", "tif", "tiff", "ttf", "woff", "xls", "xlsx", "zip"
         ],
         "isBinary": true
-    },
-
-    "haskell": {
-        "name": "Haskell",
-        "mode": "haskell",
-        "fileExtensions": ["hs"],
-        "blockComment": ["{-", "-}"],
-        "lineComment": ["--"]
     }
 }


### PR DESCRIPTION
Fixes #208 