### PR TITLE
Fix #211: load smaller versions (via grunt) of ecma5.json and browser.json using require

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -449,11 +449,39 @@ module.exports = function (grunt) {
                 src: ['**/*'],
                 dest: 'dist/'
             }
+        },
+
+        // Reduce the size of Tern.js def files by stripping !doc and !url fields,
+        // Which seem to be unused in Brackets. Turn something like this:
+        //
+        // "assign": {
+        //   "!type": "fn(url: string)",
+        //   "!url": "https://developer.mozilla.org/en/docs/DOM/window.location",
+        //   "!doc": "Load the document at the provided URL."
+        // }
+        //
+        // into this:
+        //
+        // "assign": {
+        //   "!type": "fn(url: string)"
+        // }
+        replace: {
+            ternDefs: {
+                src: ['src/extensions/default/JavaScriptCodeHints/thirdparty/tern/defs/*.json'],
+                dest: 'dist/extensions/default/JavaScriptCodeHints/thirdparty/tern/defs/',
+                replacements: [{
+                    from: /,?\n\s*"!url":[^\n]+\n(\s*"!doc":[^\n]+\n)?/g,
+                    to: ''
+                }]
+            }
         }
     });
     
     // Load postcss
     grunt.loadNpmTasks('grunt-postcss');
+
+    // Load text-replace
+    grunt.loadNpmTasks('grunt-text-replace');
 
     // Bramble-task: smartCheckout
     //   Checks out to the branch provided as a target.
@@ -534,7 +562,7 @@ module.exports = function (grunt) {
     ]);
 
     // task: build dist/ for browser
-    grunt.registerTask('build-browser', ['build', 'uglify']);
+    grunt.registerTask('build-browser', ['build', 'replace:ternDefs', 'uglify']);
 
     // task: build dist/ for browser, pre-compressed with gzip
     grunt.registerTask('build-browser-compressed', ['build-browser', 'compress']);

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
         "grunt-shell": "^1.1.2",
         "grunt-targethtml": "0.2.6",
         "grunt-template-jasmine-requirejs": "0.1.0",
+        "grunt-text-replace": "^0.4.0",
         "grunt-update-submodules": "^0.4.1",
         "grunt-usemin": "0.1.11",
         "habitat": "^3.1.2",

--- a/src/extensions/default/JavaScriptCodeHints/ScopeManager.js
+++ b/src/extensions/default/JavaScriptCodeHints/ScopeManager.js
@@ -56,7 +56,6 @@ define(function (require, exports, module) {
     
     var ternEnvironment     = [],
         pendingTernRequests = {},
-        builtinFiles        = ["ecma5.json", "browser.json", "jquery.json"],
         builtinLibraryNames = [],
         isDocumentDirty     = false,
         _hintCount          = 0,
@@ -85,24 +84,19 @@ define(function (require, exports, module) {
      * Read in the json files that have type information for the builtins, dom,etc
      */
     function initTernEnv() {
-        var path = ExtensionUtils.getModulePath(module, "thirdparty/tern/defs/"),
-            files = builtinFiles,
-            library;
+        function loadDef(defJSON) {
+            var library = JSON.parse(defJSON);
+            builtinLibraryNames.push(library["!name"]);
+            ternEnvironment.push(library);
+        }
 
-        files.forEach(function (i) {
-            FileSystem.resolve(path + i, function (err, file) {
-                if (!err) {
-                    FileUtils.readAsText(file).done(function (text) {
-                        library = JSON.parse(text);
-                        builtinLibraryNames.push(library["!name"]);
-                        ternEnvironment.push(library);
-                    }).fail(function (error) {
-                        console.log("failed to read tern config file " + i);
-                    });
-                } else {
-                    console.log("failed to read tern config file " + i);
-                }
-            });
+        require([
+            "text!thirdparty/tern/defs/ecma5.json",
+            "text!thirdparty/tern/defs/browser.json"
+        ],
+        function(ecma5, browser) {
+            loadDef(ecma5);
+            loadDef(browser);
         });
     }
 


### PR DESCRIPTION
This does a few things.  Tern uses JSON type definition files to allow you to seed the JS analysis engines with various globals (e.g., `window`, JS builtins, etc).  Brackets does this work by loading these files from the filesystem at startup.  We can't do this because our filesystem is empty at startup.  We can, however, use `require` to load them in with the `text` plugin.

I've also written some code to dramatically shrink the size of these files by pulling out all the documentation that isn't used by Brackets.  I do this in a grunt task, so it will continue to work if they update those files upstream in the tern.js code.  This saves us over 100K on the `browser.json` file, for example (was 157K and after replace it's 46K).