### PR TITLE
Add query string overrides for extension loading: extraExtensions and disabledExtensions

### DIFF
--- a/src/utils/ExtensionLoader.js
+++ b/src/utils/ExtensionLoader.js
@@ -418,11 +418,11 @@ define(function (require, exports, module) {
                 "brackets-paste-and-indent"
             ];
 
-            // Add any extra extensions we found on qs extraExtensions param
+            // Add any extra extensions we found on the query string's extraExtensions param
             if (params.get("extraExtensions")) {
-                var extraExtensions = params.get("extraExtensions").split(/\s*\,\s*/);
+                var extraExtensions = params.get("extraExtensions").split(",");
                 extraExtensions.forEach(function (ext) {
-                    ext = ext.trimRight().trimLeft();
+                    ext = ext.trim();
                     if (defaultExtensions.indexOf(ext) === -1) {
                         console.log('[Brackets] Loading additional extension `' + ext + '`');
                         defaultExtensions.push(ext);
@@ -430,11 +430,11 @@ define(function (require, exports, module) {
                 });
             }
 
-            // Disable any extensions we found on qs disabledExtensions param
+            // Disable any extensions we found on the query string's disabledExtensions param
             if (params.get("disabledExtensions")) {
-                var disabledExtensions = params.get("disabledExtensions").split(/\s*\,\s*/);
+                var disabledExtensions = params.get("disabledExtensions").split(",");
                 disabledExtensions.forEach(function (ext) {
-                    ext = ext.trimRight().trimLeft();
+                    ext = ext.trim();
                     var idx = defaultExtensions.indexOf(ext);
                     if (idx > -1) {
                         console.log('[Brackets] Disabling default extension `' + ext + '`');


### PR DESCRIPTION
I want a way for Thimble (or whatever hosting app) to be able to alter the set of extensions we load, either by turning some on, or turning some off.  This adds query string handling in the extension loader, which looks for `extraExtensions` and `disabledExtensions`.  If either is found, the set of default extensions is modified.

This will let us easily land extensions and test them without turing them on by default, or quickly disable a failing extension on production.