### PR TITLE
Fix #270 - update Filer to get upstream fs.rename() fix, use filer.min in Brackets

### DIFF
--- a/src/filesystem/impls/filer/BracketsFiler.js
+++ b/src/filesystem/impls/filer/BracketsFiler.js
@@ -3,7 +3,8 @@
 define(function (require, exports, module) {
     "use strict";
 
-    var Filer = require("thirdparty/filer/dist/filer");
+    // If you need to debug Filer for some reason, drop the .min below
+    var Filer = require("thirdparty/filer/dist/filer.min");
     var fs;
 
     Filer.fs = function() {


### PR DESCRIPTION
Updating submodule to get fix in https://github.com/filerjs/filer/pull/351.  Also uses the smaller `filer.min.js` in Brackets.  I've tested all this in the built `dist/` for brackets and works in browser.