### PR TITLE
Fix #232 - [IE10] DOM7001: Invalid argument 'url'. Failed to revoke Blob URL: 'undefined'

### DIFF
--- a/src/filesystem/impls/filer/BlobUtils.js
+++ b/src/filesystem/impls/filer/BlobUtils.js
@@ -32,6 +32,12 @@ define(function (require, exports, module) {
         filename = Path.normalize(filename);
 
         var url = blobURLs[filename];
+        // The first time a file is written, we won't have
+        // a stale cache entry to clean up.
+        if(!url) {
+            return;
+        }
+
         delete blobURLs[filename];
         delete paths[url];
         // Delete the reference from memory


### PR DESCRIPTION
This includes the fix to bbld to revoke the `blobURL` vs. `blob`.