### PR TITLE
Fix #134: Phase out file:/// URIs and replace with BlobUtils

### DIFF
--- a/src/editor/ImageViewer.js
+++ b/src/editor/ImageViewer.js
@@ -35,12 +35,17 @@ define(function (require, exports, module) {
         Strings             = require("strings"),
         StringUtils         = require("utils/StringUtils"),
         FileSystem          = require("filesystem/FileSystem"),
+        BlobUtils           = require("filesystem/impls/filer/BlobUtils"),
         FileUtils           = require("file/FileUtils"),
         _                   = require("thirdparty/lodash");
-    
-    
+
     var _viewers = {};
-        
+
+    // Get a Blob URL out of the cache
+    function _getImageUrl(file) {
+        return BlobUtils.getUrl(FileUtils.encodeFilePath(file.fullPath));
+    }
+
     /**
      * ImageView objects are constructed when an image is opened 
      * @see {@link Pane} for more information about where ImageViews are rendered
@@ -51,8 +56,7 @@ define(function (require, exports, module) {
      */
     function ImageView(file, $container) {
         this.file = file;
-        this.$el = $(Mustache.render(ImageViewTemplate, {fullPath: FileUtils.encodeFilePath(file.fullPath),
-                                                         now: new Date().valueOf()}));
+        this.$el = $(Mustache.render(ImageViewTemplate, {imgUrl: _getImageUrl(file)}));
         
         $container.append(this.$el);
 
@@ -393,22 +397,8 @@ define(function (require, exports, module) {
      * Refreshes the image preview with what's on disk
      */
     ImageView.prototype.refresh = function () {
-        var noCacheUrl = this.$imagePreview.attr("src"),
-            now = new Date().valueOf(),
-            index = noCacheUrl.indexOf("?");
-
-        // strip the old param off 
-        if (index > 0) {
-            noCacheUrl = noCacheUrl.slice(0, index);
-        }
-        
-        // add a new param which will force chrome to 
-        //  re-read the image from disk 
-        noCacheUrl = noCacheUrl + "?ver=" + now;
-        
-
         // Update the DOM node with the src URL 
-        this.$imagePreview.attr("src", noCacheUrl);
+        this.$imagePreview.attr("src", _getImageUrl(this.file));
     };
     
     /* 

--- a/src/extensions/default/QuickView/main.js
+++ b/src/extensions/default/QuickView/main.js
@@ -40,7 +40,9 @@ define(function (require, exports, module) {
         LanguageManager     = brackets.getModule("language/LanguageManager"),
         Strings             = brackets.getModule("strings"),
         ViewUtils           = brackets.getModule("utils/ViewUtils"),
-        TokenUtils          = brackets.getModule("utils/TokenUtils");
+        TokenUtils          = brackets.getModule("utils/TokenUtils"),
+        Path                = brackets.getModule("filesystem/impls/filer/BracketsFiler").Path,
+        BlobUtils           = brackets.getModule("filesystem/impls/filer/BlobUtils");
    
     var previewContainerHTML       = require("text!QuickViewTemplate.html");
     
@@ -90,8 +92,6 @@ define(function (require, exports, module) {
      * }}
      */
     var popoverState = null;
-    
-    
     
     // Popover widget management ----------------------------------------------
     
@@ -483,8 +483,9 @@ define(function (require, exports, module) {
             imgPath = tokenString;
         }
         // Use this filename if this is a path with a known image extension.
+        // We'll already have this image file's Blob URL cached in BlobUtils.
         else if (!hasProtocol && isImage) {
-            imgPath = "file:///" + FileUtils.getDirectoryPath(docPath) + tokenString;
+            imgPath = BlobUtils.getUrl(Path.join(FileUtils.getDirectoryPath(docPath), tokenString));
         }
 
         if (!imgPath) {
@@ -508,7 +509,6 @@ define(function (require, exports, module) {
         var showHandler = function () {
             // Hide the preview container until the image is loaded.
             $previewContainer.hide();
-
             $previewContainer.find(".image-preview > img").on("load", function () {
                 $previewContent
                     .append("<div class='img-size'>" +

--- a/src/htmlContent/image-view.html
+++ b/src/htmlContent/image-view.html
@@ -6,7 +6,7 @@
         </div>
         <div class="image">
             <div class="image-scale"></div>
-            <img class="image-preview" src="file:///{{fullPath}}?ver={{now}}">
+            <img class="image-preview" src="{{imgUrl}}">
             <div class="image-tip">
                 <table class="tip-container">
                     <tr>


### PR DESCRIPTION
This leverages the fact that all our fs writes cache Blob URLs already, making this really easy.