### PR TITLE
Load css.json for WebPlatformDocs extension using XHR vs filesystem

### DIFF
--- a/src/extensions/default/WebPlatformDocs/main.js
+++ b/src/extensions/default/WebPlatformDocs/main.js
@@ -30,8 +30,6 @@ define(function (require, exports, module) {
 
     // Core modules
     var EditorManager        = brackets.getModule("editor/EditorManager"),
-        FileSystem           = brackets.getModule("filesystem/FileSystem"),
-        FileUtils            = brackets.getModule("file/FileUtils"),
         ExtensionUtils       = brackets.getModule("utils/ExtensionUtils"),
         CSSUtils             = brackets.getModule("language/CSSUtils");
     
@@ -50,26 +48,19 @@ define(function (require, exports, module) {
     function getCSSDocs() {
         if (!_cssDocsPromise) {
             var result = new $.Deferred();
-            
-            var path = ExtensionUtils.getModulePath(module, "css.json"),
-                file = FileSystem.getFileForPath(path);
-            
-            FileUtils.readAsText(file)
-                .done(function (text) {
-                    var jsonData;
-                    try {
-                        jsonData = JSON.parse(text);
-                    } catch (ex) {
-                        console.error("Malformed CSS documentation database: ", ex);
-                        result.reject();
-                    }
-                    result.resolve(jsonData);  // ignored if we already reject()ed above
-                })
-                .fail(function (err) {
-                    console.error("Unable to load CSS documentation database: ", err);
-                    result.reject();
-                });
-            
+
+            $.ajax({
+                url: ExtensionUtils.getModulePath(module, "css.json"),
+                dataType: "json"
+            })
+            .done(function(data, status, jqXHR) {
+                result.resolve(data);
+            })
+            .fail(function(jqXHR, status, err) {
+                console.error("Unable to load CSS documentation database: ", err);
+                result.reject();
+            });
+
             _cssDocsPromise = result.promise();
         }
         


### PR DESCRIPTION
This lets the WebPlatformDocs extension work by using XHR instead of a local filesystem read.

To test:
* http://localhost:8080/src/index.html?enableExtensions=WebPlatformDocs
* open style.css in the filesystem
* navigate to the `color` property and right-click > Quick Docs.  You should get docs for this property.