### PR TITLE
Fix #238: Add Markdown support, transforming into HTML Blob URLs

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -37,3 +37,6 @@
 [submodule "src/extensions/extra/brackets-cdn-suggestions"]
 	path = src/extensions/extra/brackets-cdn-suggestions
 	url = https://github.com/szdc/brackets-cdn-suggestions.git
+[submodule "src/thirdparty/marked"]
+	path = src/thirdparty/marked
+	url = https://github.com/chjj/marked.git

--- a/src/filesystem/impls/filer/lib/MarkdownRewriter.js
+++ b/src/filesystem/impls/filer/lib/MarkdownRewriter.js
@@ -1,0 +1,14 @@
+/*jslint vars: true, plusplus: true, devel: true, nomen: true, regexp: true, indent: 4, maxerr: 50 */
+/*global define */
+define(function (require, exports) {
+    "use strict";
+
+    var marked = require("thirdparty/marked/marked.min");
+
+    function rewrite(path, markdown) {
+        // Run the markdown through https://github.com/chjj/marked to get HTML
+        return marked(markdown);
+    }
+
+    exports.rewrite = rewrite;
+});

--- a/src/filesystem/impls/filer/lib/content.js
+++ b/src/filesystem/impls/filer/lib/content.js
@@ -3,41 +3,33 @@
 define(function (require, exports, module) {
     "use strict";
 
-    module.exports = {
-        isMedia: function(ext) {
-            return ext === '.avi'  ||
-                   ext === '.mpeg' ||
-                   ext === '.mp4'  ||
-                   ext === '.ogg'  ||
-                   ext === '.webm' ||
-                   ext === '.mov'  ||
-                   ext === '.qt'   ||
-                   ext === '.divx' ||
-                   ext === '.wmv'  ||
-                   ext === '.mp3'  ||
-                   ext === '.wav';
-        },
+    var LanguageManager = require('language/LanguageManager');
 
+    function _getLanguageId(ext) {
+        ext = ext.replace(/^\./, "");
+        var language = LanguageManager.getLanguageForExtension(ext);
+        return language ? language.getId() : "";
+    }
+
+    module.exports = {
         isImage: function(ext) {
-            return ext === '.png'  ||
-                   ext === '.jpg'  ||
-                   ext === '.jpe'  ||
-                   ext === '.pjpg' ||
-                   ext === '.jpeg' ||
-                   ext === '.gif'  ||
-                   ext === '.bmp'  ||
-                   ext === '.ico';
+            var id = _getLanguageId(ext);
+            return id === "image" || id === "svg";
         },
 
         isHTML: function(ext) {
-            return ext === '.html' ||
-                   ext === '.htm'  ||
-                   ext === '.htx'  ||
-                   ext === '.htmls';
+            var id = _getLanguageId(ext);
+            return id === "html";
         },
 
         isCSS: function(ext) {
-            return ext === '.css';
+            var id = _getLanguageId(ext);
+            return id === "css";
+        },
+
+        isMarkdown: function(ext) {
+            var id = _getLanguageId(ext);
+            return id === "markdown";
         },
 
         mimeFromExt: function(ext) {
@@ -46,6 +38,9 @@ define(function (require, exports, module) {
             case '.htmls':
             case '.htm':
             case '.htx':
+            // We transform Markdown into HTML
+            case '.md':
+            case '.markdown':
                 return 'text/html';
             case '.ico':
                 return 'image/x-icon';

--- a/src/filesystem/impls/filer/lib/handlers.js
+++ b/src/filesystem/impls/filer/lib/handlers.js
@@ -5,23 +5,30 @@ define(function (require, exports, module) {
 
     var Content = require("filesystem/impls/filer/lib/content");
     var HTMLRewriter = require("filesystem/impls/filer/lib/HTMLRewriter");
+    var MarkdownRewriter = require("filesystem/impls/filer/lib/MarkdownRewriter");
     var CSSRewriter = require("filesystem/impls/filer/lib/CSSRewriter");
     var Path  = require("filesystem/impls/filer/BracketsFiler").Path;
     var BlobUtils = require("filesystem/impls/filer/BlobUtils");
 
     /**
-     * Send the raw file, making it somewhat more readable
+     * Process known files into Blob URLs, processing known types first
+     * so they are rendered and rewritten (e.g., paths->blob urls) properly.
      */
     function handleFile(path, data) {
         var ext = Path.extname(path);
         var mimeType = Content.mimeFromExt(ext);
 
+        // NOTE: we call toString() on `data` so that only utf8 data is used if a
+        // buffer was passed in as a parameter
+        data = data.toString();
+
         if(Content.isHTML(ext)) {
-            // We call toString on the data so that only utf8 data is used if a
-            // buffer was passed in as a parameter
-            data = HTMLRewriter.rewrite(path, data.toString());
+            data = HTMLRewriter.rewrite(path, data);
+        } else if(Content.isMarkdown(ext)) {
+            // Convert Markdown to HTML, then rewrite the resulting HTML
+            data = HTMLRewriter.rewrite(path, MarkdownRewriter.rewrite(path, data));
         } else if(Content.isCSS(ext)) {
-            data = CSSRewriter.rewrite(path, data.toString());
+            data = CSSRewriter.rewrite(path, data);
         }
 
         return BlobUtils.createURL(path, data, mimeType);


### PR DESCRIPTION
This adds backend support for Markdown, running it through a renderer before storing in our Blob URL cache.  This means that we will be able to display HTML versions of Markdown files when we add UI code that uses it.  For now it will just silently do it in the background.