### PR TITLE
Fix #316 - Allow dropping files on Bramble

### DIFF
--- a/src/filesystem/impls/filer/FilerFileSystem.js
+++ b/src/filesystem/impls/filer/FilerFileSystem.js
@@ -185,8 +185,7 @@ define(function (require, exports, module) {
             callback = options;
         }
         options = options || {};
-
-        var encoding = options.encoding || "utf8";
+        options.encoding = options.encoding === null ? null : "utf8";
 
         // Execute the read and stat calls in parallel. Callback early if the
         // read call completes first with an error; otherwise wait for both
@@ -208,7 +207,7 @@ define(function (require, exports, module) {
             });
         }
 
-        fs.readFile(path, encoding, function (_err, _data) {
+        fs.readFile(path, options.encoding, function (_err, _data) {
             if (_err) {
                 callback(_mapError(_err));
                 return;
@@ -228,11 +227,10 @@ define(function (require, exports, module) {
             callback = options;
         }
         options = options || {};
-
-        var encoding = options.encoding || "utf8";
+        options.encoding = options.encoding === null ? null : "utf8";
 
         function _finishWrite(created) {
-            fs.writeFile(path, data, encoding, function (err) {
+            fs.writeFile(path, data, options.encoding, function (err) {
                 if (err) {
                     callback(_mapError(err));
                     return;
@@ -263,7 +261,7 @@ define(function (require, exports, module) {
                 console.error("Blind write attempted: ", path, stats._hash, options.expectedHash);
 
                 if (options.hasOwnProperty("expectedContents")) {
-                    fs.readFile(path, encoding, function (_err, _data) {
+                    fs.readFile(path, options.encoding, function (_err, _data) {
                         if (_err || _data !== options.expectedContents) {
                             callback(FileSystemError.CONTENTS_MODIFIED);
                             return;

--- a/src/filesystem/impls/filer/lib/content.js
+++ b/src/filesystem/impls/filer/lib/content.js
@@ -50,6 +50,8 @@ define(function (require, exports, module) {
                 return 'text/css';
             case '.js':
                 return 'text/javascript';
+            case '.txt':
+                return 'text/plain';
             case '.svg':
                 return 'image/svg+xml';
             case '.png':
@@ -88,11 +90,15 @@ define(function (require, exports, module) {
             return 'application/octet-stream';
         },
 
+        // Whether or not this is a text/* mime type
+        isTextType: function(mime) {
+            return (/^text/).test(mime);
+        },
+
         // Check if the file can be read in utf8 encoding
         isUTF8Encoded: function(ext) {
             var mime = this.mimeFromExt(ext);
-
-            return (/^text/).test(mime);
+            return this.isTextType(mime);
         },
 
         // Test if the given URL is really a relative path (into the fs)

--- a/src/filesystem/impls/filer/lib/handlers.js
+++ b/src/filesystem/impls/filer/lib/handlers.js
@@ -19,8 +19,10 @@ define(function (require, exports, module) {
         var mimeType = Content.mimeFromExt(ext);
 
         // NOTE: we call toString() on `data` so that only utf8 data is used if a
-        // buffer was passed in as a parameter
-        data = data.toString();
+        // buffer was passed in as a parameter and should be read as utf8.
+        if(Content.isUTF8Encoded(ext)) {
+            data = data.toString();
+        }
 
         if(Content.isHTML(ext)) {
             data = HTMLRewriter.rewrite(path, data);


### PR DESCRIPTION
This gets file drag-and-drop onto the editor working.  It leverages existing code for this already present in Brackets.  You can test by dropping any file, or files (support for multiple files is also here) onto the editor.  NOTE: you cannot drop whole folders, and it will fail with an error dialog if you try.

I've also fixed a few bugs I found along the way related to encoding issues with binary files.  Dragging an image, for example, will work now.