### PR TITLE
Remove unneeded bits of Brackets: automatic updates, node stuff, extension manager dialogs, help menu

### DIFF
--- a/src/brackets.js
+++ b/src/brackets.js
@@ -74,7 +74,6 @@ define(function (require, exports, module) {
         DefaultDialogs      = require("widgets/DefaultDialogs"),
         ExtensionLoader     = require("utils/ExtensionLoader"),
         Async               = require("utils/Async"),
-        UpdateNotification  = require("utils/UpdateNotification"),
         UrlParams           = require("utils/UrlParams").UrlParams,
         PreferencesManager  = require("preferences/PreferencesManager"),
         DragAndDrop         = require("utils/DragAndDrop"),
@@ -106,8 +105,6 @@ define(function (require, exports, module) {
     require("project/SidebarView");
     require("utils/Resizer");
     require("LiveDevelopment/main");
-    require("utils/NodeConnection");
-    require("utils/NodeDomain");
     require("utils/ColorUtils");
     require("view/ThemeManager");
     require("thirdparty/lodash");
@@ -132,9 +129,6 @@ define(function (require, exports, module) {
     require("editor/EditorOptionHandlers");
     require("editor/EditorStatusBar");
     require("editor/ImageViewer");
-    require("extensibility/InstallExtensionDialog");
-    require("extensibility/ExtensionManagerDialog");
-    require("help/HelpCommandHandlers");
     require("search/FindInFilesUI");
     require("search/FindReplace");
     
@@ -254,14 +248,6 @@ define(function (require, exports, module) {
                 });
             });
         });
-
-        // Check for updates
-        if (!params.get("skipUpdateCheck") && !brackets.inBrowser) {
-            AppInit.appReady(function () {
-                // launches periodic checks for updates cca every 24 hours
-                UpdateNotification.launchAutomaticUpdate();
-            });
-        }
     }
     
     /**

--- a/src/command/DefaultMenus.js
+++ b/src/command/DefaultMenus.js
@@ -56,7 +56,8 @@ define(function (require, exports, module) {
         menu.addMenuItem(Commands.TOGGLE_LIVE_PREVIEW_MB_MODE);
         menu.addMenuItem(Commands.FILE_PROJECT_SETTINGS);
         menu.addMenuDivider();
-        menu.addMenuItem(Commands.FILE_EXTENSION_MANAGER);
+// XXXBramble: we don't want this, it will trigger loading the ExtensionManager
+//        menu.addMenuItem(Commands.FILE_EXTENSION_MANAGER);
         
         // suppress redundant quit menu item on mac
         if (brackets.platform !== "mac" || !brackets.nativeMenus) {
@@ -164,46 +165,47 @@ define(function (require, exports, module) {
          * Help menu
          */
         menu = Menus.addMenu(Strings.HELP_MENU, Menus.AppMenuBar.HELP_MENU);
-        menu.addMenuItem(Commands.HELP_CHECK_FOR_UPDATE);
-
-        menu.addMenuDivider();
-        if (brackets.config.how_to_use_url) {
-            menu.addMenuItem(Commands.HELP_HOW_TO_USE_BRACKETS);
-        }
-        if (brackets.config.support_url) {
-            menu.addMenuItem(Commands.HELP_SUPPORT);
-        }
-        if (brackets.config.suggest_feature_url) {
-            menu.addMenuItem(Commands.HELP_SUGGEST);
-        }
-        if (brackets.config.release_notes_url) {
-            menu.addMenuItem(Commands.HELP_RELEASE_NOTES);
-        }
-        if (brackets.config.get_involved_url) {
-            menu.addMenuItem(Commands.HELP_GET_INVOLVED);
-        }
-
-        menu.addMenuDivider();
-        menu.addMenuItem(Commands.HELP_SHOW_EXT_FOLDER);
-
-        var hasAboutItem = (brackets.platform !== "mac" || !brackets.nativeMenus);
-        
-        // Add final divider only if we have a homepage URL or twitter URL or about item
-        if (hasAboutItem || brackets.config.homepage_url || brackets.config.twitter_url) {
-            menu.addMenuDivider();
-        }
-        
-        if (brackets.config.homepage_url) {
-            menu.addMenuItem(Commands.HELP_HOMEPAGE);
-        }
-        
-        if (brackets.config.twitter_url) {
-            menu.addMenuItem(Commands.HELP_TWITTER);
-        }
-        // supress redundant about menu item in mac shell
-        if (hasAboutItem) {
-            menu.addMenuItem(Commands.HELP_ABOUT);
-        }
+// XXXBramble: we don't need this, and remove so it doesn't trigger other things to load.
+//        menu.addMenuItem(Commands.HELP_CHECK_FOR_UPDATE);
+//
+//        menu.addMenuDivider();
+//        if (brackets.config.how_to_use_url) {
+//            menu.addMenuItem(Commands.HELP_HOW_TO_USE_BRACKETS);
+//        }
+//        if (brackets.config.support_url) {
+//            menu.addMenuItem(Commands.HELP_SUPPORT);
+//        }
+//        if (brackets.config.suggest_feature_url) {
+//            menu.addMenuItem(Commands.HELP_SUGGEST);
+//        }
+//        if (brackets.config.release_notes_url) {
+//            menu.addMenuItem(Commands.HELP_RELEASE_NOTES);
+//        }
+//        if (brackets.config.get_involved_url) {
+//            menu.addMenuItem(Commands.HELP_GET_INVOLVED);
+//        }
+//
+//        menu.addMenuDivider();
+//        menu.addMenuItem(Commands.HELP_SHOW_EXT_FOLDER);
+//
+//        var hasAboutItem = (brackets.platform !== "mac" || !brackets.nativeMenus);
+//        
+//        // Add final divider only if we have a homepage URL or twitter URL or about item
+//        if (hasAboutItem || brackets.config.homepage_url || brackets.config.twitter_url) {
+//            menu.addMenuDivider();
+//        }
+//        
+//        if (brackets.config.homepage_url) {
+//            menu.addMenuItem(Commands.HELP_HOMEPAGE);
+//        }
+//        
+//        if (brackets.config.twitter_url) {
+//            menu.addMenuItem(Commands.HELP_TWITTER);
+//        }
+//        // supress redundant about menu item in mac shell
+//        if (hasAboutItem) {
+//            menu.addMenuItem(Commands.HELP_ABOUT);
+//        }
         
         
         /*


### PR DESCRIPTION
This saves us ~300K of unnecessary download size (pre-gzip) by removing things in Brackets we'll never use.  It's more of the same work I did earlier with turning off LiveDev stuff.

I've left the menus in place (i.e., commented vs. deleted) at this point, since removing them won't save space, and it's unclear what our long-term menu plan is at this point.