### PR TITLE
Fix #321 - Modify the XHR shim to not change native XHR readonly properties

### DIFF
--- a/src/extensions/default/bramble/lib/xhr/XHRShim.js
+++ b/src/extensions/default/bramble/lib/xhr/XHRShim.js
@@ -32,77 +32,81 @@
 
     function XMLHttpRequestLiveDev() {
         var xhr = new XMLHttpRequest();
-        var requestUrl;
-        var abortCalled = false;
+        // Internally store properties normally attached to XHR
+        var _requestUrl;
+        var _abortCalled = false;
+        var _readyState = 0;
+        var _status = 0;
+        var _statusText = "";
+        var _response = "";
+        var _responseText = "";
+        var _responseType;
+        var _onreadystatechange;
+        var _onerror;
+        var _onload;
+        var self = this;
 
         var $open = xhr.open;
         // The async parameter for XHRs to the local file system
         // is ignored as we cannot support synchronous requests
         // and async is implicit
-        xhr.open = function(method, url, async, user, password) {
+        self.open = function(method, url, async, user, password) {
             if(!(/\:?\/\//.test(url) || /\s*data\:/.test(url))) {
-                requestUrl = url;
-                abortCalled = false;
+                _requestUrl = url;
+                _abortCalled = false;
             } else {
                 $open.apply(xhr, arguments);
             }
         };
 
         var $send = xhr.send;
-        xhr.send = function() {
-            if(!requestUrl) {
+        self.send = function() {
+            if(!_requestUrl) {
                 $send.apply(xhr, arguments);
                 return;
             }
 
             function handleError(data) {
-                xhr.status = data.status || 500;
-                xhr.statusText = data.error || "Internal Server Error";
-                xhr.readyState = 4;
+                _status = data.status || 500;
+                _statusText = data.error || "Internal Server Error";
+                _readyState = 4;
                 data.error = data.error || data;
 
-                if(typeof xhr.onreadystatechange === "function" && !abortCalled) {
-                    xhr.onreadystatechange();
+                if(typeof _onreadystatechange === "function" && !_abortCalled) {
+                    _onreadystatechange.call(self);
                 }
 
-                if(typeof xhr.onerror === "function" && !abortCalled) {
-                    return xhr.onerror(data.error);
+                if(typeof _onerror === "function" && !_abortCalled) {
+                    return _onerror.call(self, {error: data.error});
                 }
             }
 
             function setResponse(data) {
-                delete xhr.readyState;
-                delete xhr.status;
-                delete xhr.statusText;
-                delete xhr.response;
-                delete xhr.responseText;
-
-                if(data.error && !abortCalled) {
+                if(data.error && !_abortCalled) {
                     return handleError(data);
                 }
 
-                xhr.readyState = 4;
-                xhr.status = 200;
-                xhr.statusText = "OK";
+                _readyState = 4;
+                _status = 200;
+                _statusText = "OK";
 
-                var $responseType = xhr.responseType;
-                if(!$responseType || $responseType === "") {
-                    $responseType = "text";
+                if(!_responseType || _responseType === "") {
+                    _responseType = "text";
                 }
 
-                switch($responseType) {
+                switch(_responseType) {
                 case "text":
-                    xhr.response = data.content;
-                    xhr.responseText = xhr.response;
+                    _response = data.content;
+                    _responseText = _response;
                     break;
                 case "document":
-                    xhr.response = new DOMParser(data.content, data.mimeType);
-                    xhr.responseText = data.content;
+                    _response = new DOMParser(data.content, data.mimeType);
+                    _responseText = data.content;
                     break;
                 case "json":
                     try {
-                        xhr.response = JSON.parse(data.content);
-                        xhr.responseText = data.content;
+                        _response = JSON.parse(data.content);
+                        _responseText = data.content;
                     } catch(e) {
                         handleError(e);
                         return;
@@ -110,16 +114,16 @@
                     break;
                 default:
                     // TODO: We should support arraybuffers and blobs
-                    handleError("Response type of " + $responseType + " is not supported. Response type must be `text`, `document` or `json`.");
+                    handleError("Response type of " + _responseType + " is not supported. Response type must be `text`, `document` or `json`.");
                     return;
                 }
 
-                if(typeof xhr.onreadystatechange === "function" && !abortCalled) {
-                    xhr.onreadystatechange();
+                if(typeof _onreadystatechange === "function" && !_abortCalled) {
+                    _onreadystatechange.call(self);
                 }
-                if(typeof xhr.onload === "function" && !abortCalled) {
+                if(typeof _onload === "function" && !_abortCalled) {
                     // TODO: deal with addEventListener
-                    xhr.onload();
+                    _onload.call(self);
                 }
             }
 
@@ -139,40 +143,97 @@
 
             sendMessage({
                 method: "XMLHttpRequest",
-                path: requestUrl
+                path: _requestUrl
             });
 
-            xhr.readyState = 1;
+            _readyState = 1;
         };
 
-        var $abort = xhr.abort;
-        xhr.abort = function() {
-            if(!nativeXHRFn(xhr, !requestUrl, $abort, arguments)) {
-                abortCalled = true;
+        self.abort = function() {
+            if(!nativeXHRFn(xhr, !_requestUrl, xhr.abort, arguments)) {
+                _abortCalled = true;
             }
         };
 
-        var $setRequestHeader = xhr.setRequestHeader;
-        xhr.setRequestHeader = function() {
-            nativeXHRFn(xhr, !requestUrl, $setRequestHeader, arguments);
+        self.setRequestHeader = function() {
+            nativeXHRFn(xhr, !_requestUrl, xhr.setRequestHeader, arguments);
         };
 
-        var $getAllResponseHeaders = xhr.getAllResponseHeaders;
-        xhr.getAllResponseHeaders = function() {
-            return nativeXHRFn(xhr, !requestUrl, $getAllResponseHeaders, arguments);
+        self.getAllResponseHeaders = function() {
+            return nativeXHRFn(xhr, !_requestUrl, xhr.getAllResponseHeaders, arguments);
         };
 
-        var $getResponseHeader = xhr.getResponseHeader;
-        xhr.getResponseHeader = function() {
-            return nativeXHRFn(xhr, !requestUrl, $getResponseHeader, arguments);
+        self.getResponseHeader = function() {
+            return nativeXHRFn(xhr, !_requestUrl, xhr.getResponseHeader, arguments);
         };
 
-        var $overrideMimeType = xhr.overrideMimeType;
-        xhr.overrideMimeType = function() {
-            nativeXHRFn(xhr, !requestUrl, $overrideMimeType, arguments);
+        self.overrideMimeType = function() {
+            nativeXHRFn(xhr, !_requestUrl, xhr.overrideMimeType, arguments);
         };
 
-        return xhr;
+        // Expose the properties on the XHR object depending on whether
+        // it is using native XHR or our postmessage XHR
+        Object.defineProperties(self, {
+            "onreadystatechange": {
+                get: function() { return _requestUrl ? _onreadystatechange : xhr.onreadystatechange; },
+                set: function(fn) {
+                    _onreadystatechange = xhr.onreadystatechange = fn;
+                }
+            },
+            "onload": {
+                get: function() { return _requestUrl ? _onload : xhr.onload; },
+                set: function(fn) { _onload = xhr.onload = fn; }
+            },
+            "onerror": {
+                get: function() { return _requestUrl ? _onerror : xhr.onerror; },
+                set: function(fn) { _onerror = xhr.onerror = fn; }
+            },
+            "readyState": {
+                get: function() { return _requestUrl ? _readyState : xhr.readyState; }
+            },
+            "response": {
+                get: function() { return _requestUrl ? _response : xhr.response; }
+            },
+            "responseText": {
+                get: function() { return _requestUrl ? _responseText : xhr.responseText; }
+            },
+            "responseType": {
+                get: function() { return _requestUrl ? _responseType : xhr.responseType; },
+                set: function(value) {
+                    _responseType = xhr.responseType = value;
+                }
+            },
+            "responseXML": {
+                get: function() { return _requestUrl ? null : xhr.responseXML; }
+            },
+            "status": {
+                get: function() { return _requestUrl ? _status : xhr.status; }
+            },
+            "statusText": {
+                get: function() { return _requestUrl ? _statusText : xhr.statusText; }
+            },
+            "timeout": {
+                get: function() { return _requestUrl ? null : xhr.timeout; },
+                set: function(value) {
+                    if(!_requestUrl) { xhr.timeout = value; }
+                }
+            },
+            "ontimeout": {
+                get: function() { return _requestUrl ? null : xhr.ontimeout; },
+                set: function(fn) {
+                    if(!_requestUrl) { xhr.ontimeout = fn; }
+                }
+            },
+            "upload": {
+                get: function() { return _requestUrl ? null : xhr.upload; }
+            },
+            "withCredentials": {
+                get: function() { return _requestUrl ? null : xhr.withCredentials; },
+                set: function(value) {
+                    if(!_requestUrl) { xhr.withCredentials = value; }
+                }
+            }
+        });
     }
 
     global.XMLHttpRequest = XMLHttpRequestLiveDev;


### PR DESCRIPTION
This patch is actually pretty ugly. However, we don't have a choice because we need to be able to separate implementations for native XHR calls and postmessage calls while supporting both of them. Furthermore, we need to be able to simulate the readonly properties that XHR has with the caveat being that those properties are modifiable internally.