### PR TITLE
openURLInDefaultBrowser callback fix

### DIFF
--- a/src/thirdparty/browser-appshell.js
+++ b/src/thirdparty/browser-appshell.js
@@ -76,7 +76,7 @@
     },
     openURLInDefaultBrowser: function(url, callback) {
       global.open(url);
-      callback();
+      callback && callback();
     },
     quit: function() {
       functionNotImplemented();


### PR DESCRIPTION
Fixes function within browser-appshell. Check to ensure callback exists before calling it.