### PR TITLE
Fix #352: deal with encoded paths, preload blob urls, fix fs bugs

### DIFF
--- a/src/bramble/BrambleStartupProject.js
+++ b/src/bramble/BrambleStartupProject.js
@@ -23,4 +23,9 @@ define(function (require, exports, module) {
             fullPath: _fullPath
         };
     };
+
+    // If the project root gets renamed, update it
+    exports.updateRoot = function(root) {
+        _root = root;
+    };
 });

--- a/src/editor/ImageViewer.js
+++ b/src/editor/ImageViewer.js
@@ -43,7 +43,7 @@ define(function (require, exports, module) {
 
     // Get a Blob URL out of the cache
     function _getImageUrl(file) {
-        return BlobUtils.getUrl(FileUtils.encodeFilePath(file.fullPath));
+        return BlobUtils.getUrl(file.fullPath);
     }
 
     /**

--- a/src/extensions/default/bramble/main.js
+++ b/src/extensions/default/bramble/main.js
@@ -119,7 +119,11 @@ define(function (require, exports, module) {
         LiveDevelopment.open();
     }
 
-    function finishStartup() {
+    function finishStartup(err) {
+        if(err) {
+            console.warn("Unable to preload filesystem URLs", err);
+        }
+
         // Below are methods to change the preferences of brackets, more available at:
         // https://github.com/adobe/brackets/wiki/How-to-Use-Brackets#list-of-supported-preferences
         PreferencesManager.set("insertHintOnTab", true);
@@ -169,6 +173,9 @@ define(function (require, exports, module) {
         // Setup the iframe browser and Blob URL live dev servers and
         // load the initial document into the preview.
         startLiveDev();
+
+        // Preload BlobURLs for all assets in the filesystem
+        BlobUtils.preload(BrambleStartupProject.getInfo().root, finishStartup);
 
         // When the app is loaded and ready, hide the menus/toolbars
         UI.initUI(finishStartup);

--- a/src/extensions/extra/ImageUrlCodeHints/camera/index.js
+++ b/src/extensions/extra/ImageUrlCodeHints/camera/index.js
@@ -6,6 +6,9 @@
 define(function (require, exports, module) {
     "use strict";
 
+    var CommandManager = brackets.getModule("command/CommandManager");
+    var Commands       = brackets.getModule("command/Commands");
+
     var Interface = require("camera/interface");
     var Video = require("camera/video");
     var Photo = require("camera/photo");
@@ -47,6 +50,9 @@ define(function (require, exports, module) {
             if(err) {
                  return self.fail(err);
             }
+
+            // Update the file tree to show the new file
+            CommandManager.execute(Commands.FILE_REFRESH);
 
             self.success(self.savePath);
         });

--- a/src/extensions/extra/ImageUrlCodeHints/main.js
+++ b/src/extensions/extra/ImageUrlCodeHints/main.js
@@ -39,6 +39,8 @@ define(function (require, exports, module) {
         LanguageManager = brackets.getModule("language/LanguageManager"),
         ExtensionUtils  = brackets.getModule("utils/ExtensionUtils"),
         EditorManager   = brackets.getModule("editor/EditorManager"),
+        StartupProject  = brackets.getModule("bramble/BrambleStartupProject"),
+        Path            = brackets.getModule("filesystem/impls/filer/FilerUtils").Path,
         Camera          = require("camera/index"),
         CameraDialog    = require("camera-dialog"),
 
@@ -564,6 +566,7 @@ define(function (require, exports, module) {
     ImageUrlCodeHints.prototype.insertHint = function (completion) {
         var that = this;
         var cameraDialog;
+        var savePath;
 
         function insert(text) {
             var mode = that.editor.getModeForSelection();
@@ -581,7 +584,8 @@ define(function (require, exports, module) {
         }
 
         if (completion === selfieLabel) {
-            cameraDialog = new CameraDialog("/" + selfieFileName);
+            savePath = Path.join(StartupProject.getInfo().root, selfieFileName);
+            cameraDialog = new CameraDialog(savePath);
             cameraDialog.show()
                 .done(function(selfieFilePath){
                     if(selfieFilePath) {

--- a/src/filesystem/impls/filer/BracketsFiler.js
+++ b/src/filesystem/impls/filer/BracketsFiler.js
@@ -39,7 +39,7 @@ define(function (require, exports, module) {
                 }
 
                 data = new FilerBuffer(data);
-                if(options === "utf8" || options.encoding === "utf8") {
+                if(options && (options === "utf8" || options.encoding === "utf8")) {
                     data = data.toString("utf8");
                 }
 

--- a/src/filesystem/impls/filer/FilerFileSystem.js
+++ b/src/filesystem/impls/filer/FilerFileSystem.js
@@ -8,6 +8,7 @@ define(function (require, exports, module) {
         FileSystemStats = require("filesystem/FileSystemStats"),
         Filer           = require("filesystem/impls/filer/BracketsFiler"),
         BlobUtils       = require("filesystem/impls/filer/BlobUtils"),
+        decodePath      = require("filesystem/impls/filer/FilerUtils").decodePath,
         Handlers = require("filesystem/impls/filer/lib/handlers"),
         Content = require("filesystem/impls/filer/lib/content"),
         Async = require("utils/Async");
@@ -87,6 +88,8 @@ define(function (require, exports, module) {
     }
 
     function stat(path, callback) {
+        path = decodePath(path);
+
         fs.stat(path, function(err, stats) {
             if (err){
                 callback(_mapError(err));
@@ -112,12 +115,15 @@ define(function (require, exports, module) {
 
 
     function exists(path, callback) {
+        path = decodePath(path);
+
         fs.exists(path, function(exists) {
             callback(null, exists);
         });
     }
 
     function readdir(path, callback) {
+        path = decodePath(path);
         path = Path.normalize(path);
 
         fs.readdir(path, function (err, contents) {
@@ -146,6 +152,8 @@ define(function (require, exports, module) {
     }
 
     function mkdir(path, mode, callback) {
+        path = decodePath(path);
+
         if(typeof mode === 'function') {
             callback = mode;
         }
@@ -160,6 +168,9 @@ define(function (require, exports, module) {
     }
 
     function rename(oldPath, newPath, callback) {
+        oldPath = decodePath(oldPath);
+        newPath = decodePath(newPath);
+
         function updateBlobURL(err) {
             if(err) {
                 return callback(_mapError(err));
@@ -171,7 +182,7 @@ define(function (require, exports, module) {
                     return callback(_mapError(err));
                 }
 
-                if(stat.type === "FILE") {
+                if(stat.isFile) {
                     BlobUtils.rename(oldPath, newPath);
                 }
 
@@ -183,6 +194,8 @@ define(function (require, exports, module) {
     }
 
     function readFile(path, options, callback) {
+        path = decodePath(path);
+
         if(typeof options === 'function') {
             callback = options;
         }
@@ -225,6 +238,8 @@ define(function (require, exports, module) {
     }
 
     function writeFile(path, data, options, callback) {
+        path = decodePath(path);
+
         if(typeof options === 'function') {
             callback = options;
         }
@@ -320,6 +335,8 @@ define(function (require, exports, module) {
     }
 
     function unlink(path, callback) {
+        path = decodePath(path);
+
         fs.stat(path, function(err, stats) {
             if (err) {
                 callback(_mapError(err));
@@ -338,6 +355,8 @@ define(function (require, exports, module) {
     }
 
     function moveToTrash(path, callback) {
+        path = decodePath(path);
+
         // TODO: do we want to support a .trash/ dir or the like?
         unlink(path, callback);
     }
@@ -347,6 +366,7 @@ define(function (require, exports, module) {
     }
 
     function watchPath(path, callback) {
+        path = decodePath(path);
         path = Path.normalize(path);
 
         if(watchers[path]) {
@@ -364,6 +384,7 @@ define(function (require, exports, module) {
     }
 
     function unwatchPath(path, callback) {
+        path = decodePath(path);
         path = Path.normalize(path);
 
         if(watchers[path]) {

--- a/src/filesystem/impls/filer/FilerUtils.js
+++ b/src/filesystem/impls/filer/FilerUtils.js
@@ -7,4 +7,9 @@ define(function (require, exports, module) {
     // If you need to debug Path or Buffer, change away from .min versions here
     exports.Path = require("thirdparty/filer/dist/path.min");
     exports.Buffer = require("thirdparty/filer/dist/buffer.min");
+
+    // Deal with Brackets encoding filepath URIs
+    exports.decodePath = function(path) {
+        return decodeURI(path);
+    };
 });

--- a/src/hosted.html
+++ b/src/hosted.html
@@ -32,7 +32,8 @@ This page is a helper for local development.
         
         require(["bramble/api"], function(Bramble) {
             Bramble.load("#bramble",{
-                url: "index.html"
+                url: "index.html",
+                useLocationSearch: true
             });
 
             // Event listeners

--- a/src/utils/DragAndDrop.js
+++ b/src/utils/DragAndDrop.js
@@ -45,7 +45,8 @@ define(function (require, exports, module) {
         Filer           = require("filesystem/impls/filer/BracketsFiler"),
         Path            = Filer.Path,
         Content         = require("filesystem/impls/filer/lib/content"),
-        LanguageManager = require("language/LanguageManager");
+        LanguageManager = require("language/LanguageManager"),
+        StartupProject  = require("bramble/BrambleStartupProject");
 
     // 3M size limit for imported files
     var byteLimit = 3 * 1024 * 1000;
@@ -253,7 +254,7 @@ define(function (require, exports, module) {
                 reader.onload = function(e) {
                     delete reader.onload;
 
-                    var filename = Path.join('/', item.name);
+                    var filename = Path.join(StartupProject.getInfo().root, item.name);
                     var file = FileSystem.getFileForPath(filename);
 
                     // Create a Filer Buffer, and determine the proper encoding. We


### PR DESCRIPTION
I ended up finding a bunch of bad bugs while fixing this original issue:

* added way to update the startup project root (we don't have a caller yet, we'll have to do that when the project name changes)
* dealt with Brackets encoding filenames when they are used as URLs (affects names with spaces, special characters)
* added preloading for blob urls on startup so any existing items in the filesystem have blog urls when you need them (e.g., clicking on an image you dragged in last time)
* update the filetree view after we save the selfie, so the file shows
* fix paths for selfie and drag and drop to use project root vs. /
* fixed a rename bug, where blob urls didn't change (there's another bug I need to file for the case that we rename a dir--all the children need their blob url paths updated)
* fixed a bug in readFile, when options wasn't passed.