### PR TITLE
Revert change to how Brackets gets loaded, so that utils/Compatibility is done first for IE

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -81,7 +81,9 @@ define(function (require) {
         // XXXBramble: get the filesystem loading ASAP for connection with parent window
         require(["filesystem/impls/filer/RemoteFiler"], function(RemoteFiler) {
             RemoteFiler.init();
-            require("brackets");
+            // Load the brackets module. This is a self-running module that loads and
+            // runs the entire application.
+            require(["brackets"]);
         });
     });
 });


### PR DESCRIPTION
Right now IE can't load Bramble due to `trimRight` missing on `String`.  I fixed this upstream a long time ago...no idea when this got broken, but the fix is to do what I did upstream for IE originally (note the use of `[..]` around the module).  This gets Bramble loading again in IE.