### PR TITLE
Fix #357: Reload preview when files are deleted and renamed

### DIFF
--- a/src/bramble/BrambleEvents.js
+++ b/src/bramble/BrambleEvents.js
@@ -49,4 +49,12 @@ define(function (require, exports, module) {
     exports.triggerSidebarExpanded = function() {
         exports.trigger("bramble:sidebarChange", true);
     };
+
+    // file delete and rename needs to get broadcast to live dev transport
+    exports.triggerFileRenamed = function(oldFilename, newFilename) {
+        exports.trigger("fileRenamed", oldFilename, newFilename);
+    };
+    exports.triggerFileRemoved = function(filename) {
+        exports.trigger("fileRemoved", filename);
+    };
 });

--- a/src/extensions/default/bramble/lib/launcher.js
+++ b/src/extensions/default/bramble/lib/launcher.js
@@ -24,7 +24,7 @@ define(function (require, exports, module) {
         _launcherInstance = this;
     }
 
-    Launcher.prototype.launch = function(url) {
+    Launcher.prototype.launch = function(url, callback) {
         var server = this.server;
         var browser = this.browser;
 
@@ -35,6 +35,10 @@ define(function (require, exports, module) {
                 return;
             }
             browser.update(urlOrHTML);
+
+            if(typeof callback === "function") {
+                callback();
+            }
         });
     };
 

--- a/src/filesystem/impls/filer/FilerFileSystem.js
+++ b/src/filesystem/impls/filer/FilerFileSystem.js
@@ -9,9 +9,10 @@ define(function (require, exports, module) {
         Filer           = require("filesystem/impls/filer/BracketsFiler"),
         BlobUtils       = require("filesystem/impls/filer/BlobUtils"),
         decodePath      = require("filesystem/impls/filer/FilerUtils").decodePath,
-        Handlers = require("filesystem/impls/filer/lib/handlers"),
-        Content = require("filesystem/impls/filer/lib/content"),
-        Async = require("utils/Async");
+        Handlers        = require("filesystem/impls/filer/lib/handlers"),
+        Content         = require("filesystem/impls/filer/lib/content"),
+        Async           = require("utils/Async"),
+        BrambleEvents   = require("bramble/BrambleEvents");
 
     var fs              = Filer.fs(),
         Path            = Filer.Path,
@@ -184,6 +185,7 @@ define(function (require, exports, module) {
 
                 if(stat.isFile) {
                     BlobUtils.rename(oldPath, newPath);
+                    BrambleEvents.triggerFileRenamed(oldPath, newPath);
                 }
 
                 callback();
@@ -349,6 +351,10 @@ define(function (require, exports, module) {
                 // TODO: deal with the symlink case (i.e., only remove cache
                 // item if file is really going away).
                 BlobUtils.remove(path);
+
+                if(!err) {
+                    BrambleEvents.triggerFileRemoved(path);
+                }
                 callback(_mapError(err));
             });
         });


### PR DESCRIPTION
This was harder to fix than I thought, because the obvious ways of fixing it caused infinite reload loops.  I've added code to guard against re-entrant reloads for the same URL.