### PR TITLE
Don't warn if theme or preview mode are null

### DIFF
--- a/src/extensions/default/bramble/lib/UI.js
+++ b/src/extensions/default/bramble/lib/UI.js
@@ -65,25 +65,29 @@ define(function (require, exports, module) {
      */
     function restoreState() {
         var theme = BrambleStartupState.ui("theme");
-        switch(theme) {
-        case "light-theme":
-        case "dark-theme":
-            Theme.setTheme(theme);
-            break;
-        default:
-            console.warn("[Bramble] unknown theme: `" + theme + "`");
+        if(theme) {
+            switch(theme) {
+            case "light-theme":
+            case "dark-theme":
+                Theme.setTheme(theme);
+                break;
+            default:
+                console.warn("[Bramble] unknown theme: `" + theme + "`");
+            }
         }
 
         var previewMode = BrambleStartupState.ui("previewMode");
-        switch(previewMode) {
-        case "desktop":
-            showDesktopView();
-            break;
-        case "mobile":
-            showMobileView();
-            break;
-        default:
-            console.warn("[Bramble] unknown preview mode: `" + previewMode + "`");
+        if(previewMode) {
+            switch(previewMode) {
+            case "desktop":
+                showDesktopView();
+                break;
+            case "mobile":
+                showMobileView();
+                break;
+            default:
+                console.warn("[Bramble] unknown preview mode: `" + previewMode + "`");
+            }
         }
 
         var sidebarWidth = BrambleStartupState.ui("sidebarWidth");


### PR DESCRIPTION
I missed this before, it just stops us from warning in the console when we don't need to.