### PR TITLE
FIX: Keep bg of mobile view white even in dark mode

### DIFF
--- a/src/extensions/default/bramble/stylesheets/style.css
+++ b/src/extensions/default/bramble/stylesheets/style.css
@@ -29,6 +29,10 @@
     background-image: url("../lib/appbar.fullscreen.box.svg");
 }
 
+#second-pane {
+    background: white !important;
+}
+
 .second-pane-scroll {
     overflow: scroll !important;
 }


### PR DESCRIPTION
to solve [thimble#582](https://github.com/mozilla/thimble.webmaker.org/issues/582)