### PR TITLE
Fix #367 - Resize only works when you've first moved the divider

### DIFF
--- a/src/extensions/default/bramble/lib/RemoteCommandHandler.js
+++ b/src/extensions/default/bramble/lib/RemoteCommandHandler.js
@@ -13,7 +13,8 @@ define(function (require, exports, module) {
     var SidebarView    = brackets.getModule("project/SidebarView");
     var StatusBar      = brackets.getModule("widgets/StatusBar");
     var WorkspaceManager = brackets.getModule("view/WorkspaceManager");
-
+    var BrambleEvents = brackets.getModule("bramble/BrambleEvents");
+    
     var PostMessageTransport = require("lib/PostMessageTransport");
     var Theme = require("lib/Theme");
     var UI = require("lib/UI");
@@ -75,6 +76,7 @@ define(function (require, exports, module) {
         case "RESIZE":
             // The host window was resized, update all panes
             WorkspaceManager.recomputeLayout(true);
+            BrambleEvents.triggerUpdateLayoutEnd();
             break;
         default:
             console.log('[Bramble] unknown command:', command);


### PR DESCRIPTION
We never send a layout event to the iframe api when we do a resize.  This fixes it.