### PR TITLE
Fix https://github.com/mozilla/thimble.webmaker.org/issues/620 - Remember last-open-file within subdirs

### DIFF
--- a/src/brackets.js
+++ b/src/brackets.js
@@ -190,7 +190,7 @@ define(function (require, exports, module) {
                 // XXXBramble: get path passed into iframe from hosting app
                 ProjectManager.openProject(BrambleStartupState.project("root")).always(function () {
                     var deferred = new $.Deferred();
-                    FileSystem.resolve(BrambleStartupState.project("fullPath"), function (err, file) {
+                    FileSystem.resolve(BrambleStartupState.project("filename"), function (err, file) {
                         if (!err) {
                             var promise = CommandManager.execute(Commands.CMD_ADD_TO_WORKINGSET_AND_OPEN, { fullPath: file.fullPath });
                             promise.then(deferred.resolve, deferred.reject);

--- a/src/bramble/client/main.js
+++ b/src/bramble/client/main.js
@@ -319,12 +319,7 @@ define([
                 setReadyState(Bramble.MOUNTING);
 
                 root = Path.normalize(root);
-                filename = filename || (_state.filename || "index.html");
-
-                if (Path.isAbsolute(filename)) {
-                    filename = Path.relative(root, filename);
-                    debug("converted absolute filename path in mount() to relative", filename);
-                }
+                filename = Path.resolve(root, filename || (_state.fullPath || "index.html"));
 
                 // Make sure the path we were given exists in the filesystem, and is a dir
                 _fs.stat(root, function(err, stats) {

--- a/src/extensions/default/bramble/main.js
+++ b/src/extensions/default/bramble/main.js
@@ -205,8 +205,7 @@ define(function (require, exports, module) {
             // to Brackets that it can keep going, which will pick this up.
             BrambleStartupState.project.init({
                 root: data.mount.root,
-                filename: data.mount.filename,
-                fullPath: Path.join(data.mount.root, data.mount.filename)
+                filename: data.mount.filename
             });
 
             // Set initial UI state values (if present)


### PR DESCRIPTION
This uses a fullpath for the initial file to open vs. just the basename.