### PR TITLE
Allow SVG to be treated as an image or XML doc in ImageViewer, with extension to override

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ In addition, you can enable other extra extensions:
 * ImageUrlCodeHints
 * HTMLHinter
 * MdnDocs
+* SVGasXML
 
 You could enable JSLint and LESSSupport by loading Bramble with `?enableExtensions=JSLint,LESSSupport`
 on the URL

--- a/src/editor/ImageViewer.js
+++ b/src/editor/ImageViewer.js
@@ -39,6 +39,10 @@ define(function (require, exports, module) {
         FileUtils           = require("file/FileUtils"),
         _                   = require("thirdparty/lodash");
 
+    // XXXBramble specific bits to allow opening SVG as a regular image vs. XML doc
+    var PreferencesManager  = require("preferences/PreferencesManager");
+    PreferencesManager.definePreference("openSVGasXML", "boolean", false);
+
     var _viewers = {};
 
     // Get a Blob URL out of the cache
@@ -455,7 +459,12 @@ define(function (require, exports, module) {
     MainViewFactory.registerViewFactory({
         canOpenFile: function (fullPath) {
             var lang = LanguageManager.getLanguageForPath(fullPath);
-            return (lang.getId() === "image");
+            var svgAsXML = PreferencesManager.get("openSVGasXML");
+            var id = lang.getId();
+
+            // Depending on whether or not the user wants to treat SVG files as XML
+            // we default to open as an image.
+            return id === "image" || (!svgAsXML && id === "svg");
         },
         openFile: function (file, pane) {
             return _createImageView(file, pane);

--- a/src/extensions/extra/SVGasXML/main.js
+++ b/src/extensions/extra/SVGasXML/main.js
@@ -1,0 +1,10 @@
+/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
+/*global define, brackets, window */
+
+define(function (require, exports, module) {
+    "use strict";
+
+    // Override SVG ImageViewer in order to display SVG's as XML
+    var PreferencesManager  = brackets.getModule("preferences/PreferencesManager");
+    PreferencesManager.set("openSVGasXML", true);
+});

--- a/src/utils/BrambleExtensionLoader.js
+++ b/src/utils/BrambleExtensionLoader.js
@@ -62,7 +62,8 @@ define(function (require, exports, module) {
         "brackets-cdn-suggestions",    // https://github.com/szdc/brackets-cdn-suggestions
         "ImageUrlCodeHints",
         "HTMLHinter",
-        "MDNDocs"
+        "MDNDocs",
+        "SVGasXML"
     ];
 
     // Disable any extensions we found on the query string's disableExtensions param


### PR DESCRIPTION
Discovered while working on https://github.com/mozilla/thimble.webmaker.org/pull/654#issuecomment-118167503 -- an SVG opens as an XML file in the editor vs. an image.  For our users, they will mostly want to see SVG as an image.  This defaults to SVG-as-Image, and allows you to override by including the optional `SVGasXML` extension.