### PR TITLE
Fix https://github.com/mozilla/thimble.webmaker.org/issues/635 - proper resize code for sidebar on startup

### DIFF
--- a/src/extensions/default/bramble/lib/UI.js
+++ b/src/extensions/default/bramble/lib/UI.js
@@ -92,7 +92,7 @@ define(function (require, exports, module) {
 
         var sidebarWidth = BrambleStartupState.ui("sidebarWidth");
         if(sidebarWidth) {
-            $("#sidebar").width(sidebarWidth);
+            SidebarView.resize(sidebarWidth);
         }
 
         var sidebarVisible = BrambleStartupState.ui("sidebarVisible");

--- a/src/project/SidebarView.js
+++ b/src/project/SidebarView.js
@@ -105,6 +105,26 @@ define(function (require, exports, module) {
     }
     
     /**
+     * XXXBramble: allow resizing programmatically
+     */
+    function resize(width) {
+        $sidebar.width(width);
+
+        ProjectManager._setFileTreeSelectionWidth(width);
+
+        var $element;
+        $sidebar.find(".sidebar-selection").each(function (index, element) {
+            $element = $(element);
+            $element.width($element.parent()[0].scrollWidth);
+        });
+
+        $sidebar.find(".sidebar-selection-extension").css("display", "block").css("left", width);
+        $sidebar.find(".scroller-shadow").css("display", "block");
+        $projectFilesContainer.triggerHandler("scroll");
+        WorkingSetView.syncSelectionIndicator();
+    }
+
+    /**
      * Returns the visibility state of the sidebar.
      * @return {boolean} true if element is visible, false if it is not visible
      */
@@ -279,4 +299,5 @@ define(function (require, exports, module) {
     exports.show        = show;
     exports.hide        = hide;
     exports.isVisible   = isVisible;
+    exports.resize      = resize;
 });


### PR DESCRIPTION
On startup, I was manually adjusting the size of the sidebar element, but not triggering all the necessary resizing code that has to happen in order to update the selection width, etc.  This fixes that by exposing a proper `resize()` method on the sidebar, and calling the same code that would happen with a real resize.

I've also filed https://github.com/adobe/brackets/issues/11341 upstream to deal with the resize case.