### PR TITLE
Don't wait on focus for Brackets commands that don't require it (e.g., saveAll)

### DIFF
--- a/src/extensions/default/bramble/lib/RemoteCommandHandler.js
+++ b/src/extensions/default/bramble/lib/RemoteCommandHandler.js
@@ -33,13 +33,25 @@ define(function (require, exports, module) {
             CommandManager.execute(Commands[command]).always(callback);
         }
 
-        // Make sure the last-focused editor gets focus before executing
-        var editor = EditorManager.getActiveEditor();
-        if (editor && !editor.hasFocus()) {
-            editor.one("focus", executeCommand);
-            editor.focus();
-        } else {
+        // Some commands require focus in the editor
+        switch(command) {
+        case "EDIT_UNDO":
+        case "EDIT_REDO":
+        case "VIEW_INCREASE_FONT_SIZE":
+        case "VIEW_DECREASE_FONT_SIZE":
+        case "VIEW_RESTORE_FONT_SIZE":
+            // Make sure the last-focused editor gets focus before executing
+            var editor = EditorManager.getActiveEditor();
+            if (editor && !editor.hasFocus()) {
+                editor.one("focus", executeCommand);
+                editor.focus();
+            } else {
+                executeCommand();
+            }
+            break;
+        default:
             executeCommand();
+            break;
         }
     }
 


### PR DESCRIPTION
This let's us call things from the console via the `bramble` instance.  We'll have to remember this later if we add support for more Brackets commands.