### PR TITLE
Autosave after 5s vs. 30s of making an editor dirty

### DIFF
--- a/src/extensions/default/Autosave/main.js
+++ b/src/extensions/default/Autosave/main.js
@@ -19,7 +19,7 @@ define(function (require, exports, module) {
      */
 
     // Time in ms to wait after a dirtyFlagChange event before autosaving file
-    var SAVE_DELAY_MS = 30 * 1000;
+    var SAVE_DELAY_MS = 5 * 1000;
 
     // Whether or not to autosave immediately when the user switches away from
     // a dirty editor document.


### PR DESCRIPTION
This alters our Autosave logic such that it will save 5s after a change is made to an editor.  Previously it was 30s, but I think that was frustrating users.