### PR TITLE
Fix https://github.com/mozilla/thimble.webmaker.org/issues/674 - remo…

### DIFF
--- a/src/command/DefaultMenus.js
+++ b/src/command/DefaultMenus.js
@@ -244,12 +244,13 @@ define(function (require, exports, module) {
         project_cmenu.addMenuItem(Commands.FILE_NEW_FOLDER);
         project_cmenu.addMenuItem(Commands.FILE_RENAME);
         project_cmenu.addMenuItem(Commands.FILE_DELETE);
-        project_cmenu.addMenuItem(Commands.NAVIGATE_SHOW_IN_OS);
-        project_cmenu.addMenuDivider();
-        project_cmenu.addMenuItem(Commands.CMD_FIND_IN_SUBTREE);
-        project_cmenu.addMenuItem(Commands.CMD_REPLACE_IN_SUBTREE);
-        project_cmenu.addMenuDivider();
-        project_cmenu.addMenuItem(Commands.FILE_REFRESH);
+// XXXBramble: not something we want to support at the moment/ever
+//        project_cmenu.addMenuItem(Commands.NAVIGATE_SHOW_IN_OS);
+//        project_cmenu.addMenuDivider();
+//        project_cmenu.addMenuItem(Commands.CMD_FIND_IN_SUBTREE);
+//        project_cmenu.addMenuItem(Commands.CMD_REPLACE_IN_SUBTREE);
+//        project_cmenu.addMenuDivider();
+//        project_cmenu.addMenuItem(Commands.FILE_REFRESH);
         
         var editor_cmenu = Menus.registerContextMenu(Menus.ContextMenuIds.EDITOR_MENU);
         // editor_cmenu.addMenuItem(Commands.NAVIGATE_JUMPTO_DEFINITION);


### PR DESCRIPTION
Removes items from file tree context menu.  I disagree with removing `New Folder` since we have no other way to do it at the moment, and it's a highly useful feature to expose.  I was unable to remove the `F2` visual keybinding.  I've done the rest.