### PR TITLE
Fix #385 - add logic for renaming project root via second call to Bramble.mount()

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,6 +246,27 @@ fs.mkdir("/project", function(err) {
 });
 ```
 
+After a project root directory is mounted, it can later be updated by calling `Bramble.mount()`
+a second time.  For example, if you need to rename the project folder:
+
+```js
+Bramble.mount("/project");
+...
+// Rename the project root dir in the filesystem
+fs.rename("/project", "/renamed-project", function(err) {
+  if (err) {
+    throw err;
+  }
+
+  // Now let Bramble know that the root dir has been changed,
+  // waiting on an event from the Bramble instance to tell us it worked.
+  bramble.once("mountRenamed", function() {
+    // The mount info was updated
+  });
+  Bramble.mount("/renamed-project");
+});
+```
+
 ## Bramble Instance Getters
 
 Once the Bramble instance is created (e.g., via `ready` event or `Bramble.mount()` callback),
@@ -310,6 +331,7 @@ the following events:
 * `"themeChange"` - triggered whenever the theme changes. It inclues an `Object` with a `theme` property that indicates the new theme
 * `"fontSizeChange"` - triggered whenever the font size changes. It includes an `Object` with a `fontSize` property that indicates the new size (e.g., `"12px"`).
 * `"wordWrapChange"` - triggered whenever the word wrap value changes. It includes an `Object` with a `wordWrap` property that indicates the new value (e.g., `true` or `false`).
+* `"mountRenamed"` - triggered when `Bramble.mount()` is called after mounting, indicating that project root info has been updated in the instance.
 
 There are also high-level events for changes to files:
 

--- a/src/bramble/StartupState.js
+++ b/src/bramble/StartupState.js
@@ -1,4 +1,5 @@
-/* jslint newcap:true */
+/* jslintnewcap:true */
+/* global parent */
 
 define(function (require, exports, module) {
     "use strict";
@@ -29,5 +30,28 @@ define(function (require, exports, module) {
 
     exports.project.init = function(state) {
         _project = Map(state);
+    };
+
+    exports.project.handleRename = function(e) {
+        var remoteRequest;
+        try {
+            remoteRequest = JSON.parse(e.data);
+        } catch(err) {
+            console.log('[Bramble] unable to parse remote request:', e.data);
+            return;
+        }
+
+        if (remoteRequest.type !== "bramble:mountRename") {
+            return;
+        }
+
+        var renamedRoot = e.data.root;
+        _project = _project.set("root", renamedRoot);
+
+        // Let the client-side know this is complete
+        var message = {
+            type: "bramble:mountRenamed"
+        };
+        parent.postMessage(JSON.stringify(message), "*");
     };
 });

--- a/src/bramble/StartupState.js
+++ b/src/bramble/StartupState.js
@@ -5,6 +5,9 @@ define(function (require, exports, module) {
     "use strict";
 
     var Map = require("thirdparty/immutable").Map;
+    var CommandManager = require("command/CommandManager");
+    var FILE_REFRESH   = require("command/Commands").FILE_REFRESH;
+
     var _ui;
     var _project;
 
@@ -48,10 +51,13 @@ define(function (require, exports, module) {
         var renamedRoot = e.data.root;
         _project = _project.set("root", renamedRoot);
 
-        // Let the client-side know this is complete
-        var message = {
-            type: "bramble:mountRenamed"
-        };
-        parent.postMessage(JSON.stringify(message), "*");
+        // Update the file tree to show the new file
+        CommandManager.execute(FILE_REFRESH).always(function() {
+            // Let the client-side know this is complete
+            var message = {
+                type: "bramble:mountRenamed"
+            };
+            parent.postMessage(JSON.stringify(message), "*");
+        });
     };
 });

--- a/src/extensions/default/bramble/main.js
+++ b/src/extensions/default/bramble/main.js
@@ -179,6 +179,9 @@ define(function (require, exports, module) {
                 filename: data.mount.filename
             });
 
+            // Also have the project state listen for mount rename requests
+            window.addEventListener("message", BrambleStartupState.project.handleRename, false);
+
             // Set initial UI state values (if present)
             BrambleStartupState.ui.init({
                 fontSize: data.state.fontSize,


### PR DESCRIPTION
This is untested!  @gideonthomas, can you follow the instructions in the README below, and see if it works for your case?