### PR TITLE
Fix #387 - invalid CSS selector in HTMLRewriter

### DIFF
--- a/src/filesystem/impls/filer/lib/HTMLRewriter.js
+++ b/src/filesystem/impls/filer/lib/HTMLRewriter.js
@@ -114,7 +114,7 @@ define(function (require, exports, module) {
         var dir = this.dir;
         var server = this.server;
         // TODO: https://developer.mozilla.org/en-US/docs/Web/CSS/Alternative_style_sheets
-        var elements = this.doc.querySelectorAll('link[rel="stylesheet"');
+        var elements = this.doc.querySelectorAll("link[rel='stylesheet']");
 
         Async.eachSeries(elements, function(element, callback) {
             var path = element.getAttribute("href");


### PR DESCRIPTION
Amazing no other browser fails on this.