### PR TITLE
Tutorial backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,6 +262,8 @@ a number of read-only getters are available in order to access state information
 * `getTheme()` - returns the name of the current theme.
 * `getFontSize()` - returns the current font size as a string (e.g., `"12px"`).
 * `getWordWrap()` - returns the current word wrap setting as a `Boolean` (i.e., enabled or disabled).
+* `getTutorialExists()` - returns `true` or `false` depending on whether or not there is a tutorial in the project (i.e., if `tutorial.html` is present)
+* `getTutorialVisible()` - returns `true` or `false` depending on whether or not the preview browser is showing a tutorial or not.
 
 **NOTE**: calling these getters before the `ready()` callback on the bramble instance
 won't do what you want.
@@ -298,6 +300,8 @@ to be notified when the action completes:
 * `disableJavaScript([callback])` - turns off JavaScript execution for the preview
 * `enableWordWrap([callback])` - turns on word wrap for the editor (default)
 * `disableWordWrap([callback])` - turns off word wrap for the editor
+* `showTutorial([callback])` - shows tutorial (i.e., tutorial.html) vs editor contents in preview
+* `hideTutorial([callback])` - stops showing tutorial (i.e., tutorial.html) and uses editor contents in preview
 
 ## Bramble Instance Events
 
@@ -311,6 +315,9 @@ the following events:
 * `"themeChange"` - triggered whenever the theme changes. It inclues an `Object` with a `theme` property that indicates the new theme
 * `"fontSizeChange"` - triggered whenever the font size changes. It includes an `Object` with a `fontSize` property that indicates the new size (e.g., `"12px"`).
 * `"wordWrapChange"` - triggered whenever the word wrap value changes. It includes an `Object` with a `wordWrap` property that indicates the new value (e.g., `true` or `false`).
+* `"tutorialAdded"` - triggered when a new tutorial is added to the project
+* `"tutorialRemoved"` - triggered when an existing tutorial for the project is removed
+* `"tutorialVisibilityChange"` - triggered when the tutorial preview is turned on or off. It includes an `Object` with a `visibility` property that indicates whether the tutorial is visible.
 
 There are also high-level events for changes to files:
 

--- a/src/bramble/BrambleEvents.js
+++ b/src/bramble/BrambleEvents.js
@@ -57,4 +57,9 @@ define(function (require, exports, module) {
     exports.triggerFileRemoved = function(filename) {
         exports.trigger("fileRemoved", filename);
     };
+
+    // turning tutorial view on/off
+    exports.triggerTutorialVisibilityChange = function(visible) {
+        exports.trigger("bramble:tutorialVisibilityChange", visible);
+    };
 });

--- a/src/extensions/default/bramble/lib/PostMessageTransport.js
+++ b/src/extensions/default/bramble/lib/PostMessageTransport.js
@@ -20,6 +20,7 @@ define(function (require, exports, module) {
 
     // The script that will be injected into the previewed HTML to handle the other side of the post message connection.
     var PostMessageTransportRemote = require("text!lib/PostMessageTransportRemote.js");
+    var Tutorial = require("lib/Tutorial");
 
     // An XHR shim will be injected as well to allow XHR to the file system
     var XHRShim = require("text!lib/xhr/XHRShim.js");
@@ -145,7 +146,7 @@ define(function (require, exports, module) {
 
         win.postMessage(msgStr, "*");
 
-        if(detachedPreview) {
+        if(detachedPreview && Tutorial.shouldPostMessage()) {
             detachedPreview.postMessage(msgStr, "*");
         }
     }

--- a/src/extensions/default/bramble/lib/RemoteCommandHandler.js
+++ b/src/extensions/default/bramble/lib/RemoteCommandHandler.js
@@ -15,6 +15,7 @@ define(function (require, exports, module) {
     var PreferencesManager = brackets.getModule("preferences/PreferencesManager");
 
     var PostMessageTransport = require("lib/PostMessageTransport");
+    var Tutorial = require("lib/Tutorial");
     var Theme = require("lib/Theme");
     var UI = require("lib/UI");
 
@@ -101,6 +102,12 @@ define(function (require, exports, module) {
             break;
         case "BRAMBLE_DISABLE_WORD_WRAP":
             PreferencesManager.set("wordWrap", false);
+            break;
+        case "BRAMBLE_SHOW_TUTORIAL":
+            Tutorial.setOverride(true);
+            break;
+        case "BRAMBLE_HIDE_TUTORIAL":
+            Tutorial.setOverride(false);
             break;
         case "RESIZE":
             // The host window was resized, update all panes

--- a/src/extensions/default/bramble/lib/RemoteEvents.js
+++ b/src/extensions/default/bramble/lib/RemoteEvents.js
@@ -91,6 +91,14 @@ define(function (require, exports, module) {
             });
         });
 
+        // Listen for changes to Tutorial visibility
+        BrambleEvents.on("bramble:tutorialVisibilityChange", function(e, visible) {
+            sendEvent({
+                type: "bramble:tutorialVisibilityChange",
+                visible: visible
+            });
+        });
+
         // Listen for changes to the font size
         ViewCommandHandlers.on("fontSizeChange", function(e, fontSize) {
             sendEvent({

--- a/src/extensions/default/bramble/lib/Tutorial.js
+++ b/src/extensions/default/bramble/lib/Tutorial.js
@@ -1,0 +1,85 @@
+define(function (require, exports, module) {
+    "use strict";
+
+    var StartupState  = brackets.getModule("bramble/StartupState");
+    var EditorManager = brackets.getModule("editor/EditorManager");
+    var BrambleEvents = brackets.getModule("bramble/BrambleEvents");
+    var Filer         = brackets.getModule("filesystem/impls/filer/BracketsFiler");
+    var Path          = Filer.Path;
+
+    var PostMessageTransport = require("lib/PostMessageTransport");
+
+    // Whether or not we're overriding the preview with a tutorial
+    var _tutorialOverride;
+
+    // After we change the override value, and in order to get the
+    // tutorial to show, we need to force a reload for the preview.
+    var _forceReload;
+
+    // Define public API
+    function setOverride(val) {
+        _tutorialOverride = !!val;
+        _forceReload = true;
+        PostMessageTransport.reload();
+        BrambleEvents.triggerTutorialVisibilityChange(_tutorialOverride);
+    }
+
+    function getOverride() {
+        return _tutorialOverride;
+    }
+
+    function getUrl() {
+        return Path.join(StartupState.project("root"), "tutorial.html");
+    }
+
+    /**
+     * Callback returns `true` or `false`, like fs.exists().
+     */
+    function exists(callback) {
+        Filer.fs().stat(getUrl(), function(err, stats) {
+            callback(stats && stats.type === "FILE");
+        });
+    }
+
+    /**
+     * Whether or not the file currently in the editor is the tutorial file.
+     */
+    function _tutorialInEditor() {
+        var editor = EditorManager.getCurrentFullEditor();
+        if(!editor) {
+            return false;
+        }
+
+        return getUrl() === editor.document.file.fullPath;
+    }
+
+    /**
+     * When the tutorial is hijacking the preview iframe, we only
+     * need to reload when we're actually editing the tutorial.html file.
+     */
+    function shouldReload() {
+        if(_forceReload) {
+            _forceReload = false;
+            return true;
+        }
+
+        return getOverride() && _tutorialInEditor();
+    }
+
+    /**
+     * When the tutorial is hijacking the preview iframe, we don't
+     * need to spam postMessage with DOM diffs and instrumentation calls.
+     * We only want to do this if the actual tutorial.html file is open in the editor,
+     * in which case one is likely editing it, and wants to see dynamic updates.
+     */
+    function shouldPostMessage() {
+        return getOverride() && _tutorialInEditor();
+    }
+
+    exports.setOverride = setOverride;
+    exports.getOverride = getOverride;
+    exports.getUrl = getUrl;
+    exports.exists = exists;
+    exports.shouldReload = shouldReload;
+    exports.shouldPostMessage = shouldPostMessage;
+});

--- a/src/hosted.html
+++ b/src/hosted.html
@@ -70,27 +70,40 @@ This page is a helper for local development.
                 }
 
                 // Default filesystem content
-                var html = "<html>\n"                     +
-                           "  <head>\n"                   +
-                           "    <title>Bramble</title>\n" +
-                           "  </head>\n"                  +
-                           "  <body>\n"                   +
-                           "    <p>Hello World</p>\n"     +
-                           "  </body>\n"                  +
-                           "</html>";
-                var css = "p {\n"                         +
-                          "  color: purple;\n"            +
+                var index = "<html>\n"                                  +
+                            "  <head>\n"                                +
+                            "    <title>Bramble</title>\n"              +
+                            "  </head>\n"                               +
+                            "  <body>\n"                                +
+                            "    <p>This is the main page.</p>\n"       +
+                            "  </body>\n"                               +
+                            "</html>";
+
+                var tutorial = "<html>\n"                               +
+                               "  <head>\n"                             +
+                               "    <title>Tutorial</title>\n"          +
+                               "  </head>\n"                            +
+                               "  <body>\n"                             +
+                               "    <p>This is the tutorial.</p>\n"     +
+                               "  </body>\n"                            +
+                               "</html>";
+
+                var css = "p {\n"                                       +
+                          "  color: purple;\n"                          +
                           "}";
-                var script = "function add(a, b) {\n"     +
-                             "  return a|0 + b|0;\n"      +
+
+                var script = "function add(a, b) {\n"                   +
+                             "  return a|0 + b|0;\n"                    +
                              "}";
 
                 writeFile("/7/projects/30/script.js", script, function() {
                     writeFile("/7/projects/30/style.css", css, function() {
-                        writeFile("/7/projects/30/index.html", html, function() {
-                            // Now that fs is setup, tell Bramble which root dir to mount
-                            // and which file within that root to open on startup.
-                            Bramble.mount("/7/projects/30");
+                        writeFile("/7/projects/30/index.html", index, function() {
+                            writeFile("/7/projects/30/tutorial.html", tutorial, function() {
+                                // Now that fs is setup, tell Bramble which root dir to mount
+                                // and which file within that root to open on startup.
+                                Bramble.mount("/7/projects/30");
+                            });
                         });
                     });
                 });


### PR DESCRIPTION
This is the backend plumbing necessary for us to treat a `tutorial.html` file in the project root as a special thing, namely, to allow it to stay pinned in the preview while you jump around to other files.  The concept is to have `tutorial.html` be a special file, similar to how GitHub uses `readme.md`, showing it below the file listing for a directory.  By rendering a regular HTML file vs. having special backed-in UI, my hope is that e let users define what they want.