### PR TITLE
Reset tutorial override if tutorial.html file vanishes at runtime (user deleted/renamed)

### DIFF
--- a/src/extensions/default/bramble/lib/Tutorial.js
+++ b/src/extensions/default/bramble/lib/Tutorial.js
@@ -16,10 +16,10 @@ define(function (require, exports, module) {
     // tutorial to show, we need to force a reload for the preview.
     var _forceReload;
 
-    // Define public API
     function setOverride(val) {
         _tutorialOverride = !!val;
         _forceReload = true;
+
         PostMessageTransport.reload();
         BrambleEvents.triggerTutorialVisibilityChange(_tutorialOverride);
     }

--- a/src/extensions/default/bramble/lib/launcher.js
+++ b/src/extensions/default/bramble/lib/launcher.js
@@ -41,17 +41,15 @@ define(function (require, exports, module) {
         var server = _launcherInstance.server;
         var browser = _launcherInstance.browser;
 
+        callback = callback || function(){};
+
         server.serveLiveDocForUrl(url, function(err, urlOrHTML) {
             if(err) {
-                // TODO: how to deal with this error?                
                 console.error("[Launcher Error]", err);
-                return;
+                return callback();
             }
             browser.update(urlOrHTML);
-
-            if(typeof callback === "function") {
-                callback();
-            }
+            callback();
         });
     }
 
@@ -64,7 +62,8 @@ define(function (require, exports, module) {
         Tutorial.exists(function(tutorialExists) {
             if(!tutorialExists) {
                 console.error("[Launcher Error] expected tutorial.html to exist");
-                // Fallback to normal loading so we show something
+                // Reset the tutorial override, and fallback to normal loading. so we show something
+                Tutorial.setOverride(false);
                 _launch(url, callback);
             } else {
                 // Swap out the tutorial url and reload if necessary. We try hard


### PR DESCRIPTION
This fixes the case that while in tutorial override mode, the `tutorial.html` goes away (delete, rename).  In this case we can't preview it, so we need to jump out of override mode and show the regular live dev file.  I'm adding events for this in Thimble to have the UI catch this case and remove the TUTORIAL button.