### PR TITLE
Fix #739: Preview stops showing the correct preview after previewing the tutorial

### DIFF
--- a/src/extensions/default/bramble/lib/launcher.js
+++ b/src/extensions/default/bramble/lib/launcher.js
@@ -64,7 +64,6 @@ define(function (require, exports, module) {
                 console.error("[Launcher Error] expected tutorial.html to exist");
                 // Reset the tutorial override, and fallback to normal loading. so we show something
                 Tutorial.setOverride(false);
-                _launch(url, callback);
             } else {
                 // Swap out the tutorial url and reload if necessary. We try hard
                 // not to reload unless we have to, so the tutorial doesn't flicker.


### PR DESCRIPTION
This fixes things by tearing down and recreating the LiveDev connection when we exit tutorial mode, which causes Brackets to find the right file to show in the preview.