### PR TITLE
Support adding new files and folders from bramble, part of https://github.com/mozilla/thimble.webmaker.org/issues/723

### DIFF
--- a/README.md
+++ b/README.md
@@ -304,6 +304,8 @@ to be notified when the action completes:
 * `showTutorial([callback])` - shows tutorial (i.e., tutorial.html) vs editor contents in preview
 * `hideTutorial([callback])` - stops showing tutorial (i.e., tutorial.html) and uses editor contents in preview
 * `showUploadFilesDialog([callback])` - shows the Upload Files dialog, allowing users to drag-and-drop, upload a file, or take a selfie.
+* `addNewFile([ext, callback])` - adds a new file, using the optional `ext` as an extension if provided.
+* `addNewFolder([callback])` - adds a new folder.
 
 ## Bramble Instance Events
 

--- a/src/bramble/client/main.js
+++ b/src/bramble/client/main.js
@@ -674,8 +674,19 @@ define([
     };
 
     BrambleProxy.prototype.showUploadFilesDialog = function(callback) {
-        this._executeRemoteCommand({commandCategory: "bramble", command: "SHOW_UPLOAD_FILES_DIALOG"}, callback);
+        this._executeRemoteCommand({commandCategory: "bramble", command: "BRAMBLE_SHOW_UPLOAD_FILES_DIALOG"}, callback);
     };
 
+    BrambleProxy.prototype.addNewFile = function(ext, callback) {
+        if(ext) {
+            this._executeRemoteCommand({commandCategory: "bramble", command: "BRAMBLE_ADD_NEW_FILE", args: ext}, callback);
+        } else {
+            this._executeRemoteCommand({commandCategory: "brackets", command: "FILE_NEW"}, callback);
+        }
+    };
+
+    BrambleProxy.prototype.addNewFolder = function(callback) {
+        this._executeRemoteCommand({commandCategory: "brackets", command: "FILE_FOLDER"}, callback);
+    };
     return Bramble;
 });


### PR DESCRIPTION
I need this for adding HTML, CSS, and JS files from the add file popup menu.  I've also added support for adding new folders, in case we want that at some point.  I had to rejig the remote command stuff so it allowed passing args, too.

I've got UI coming for this in Thimble in a follow-up PR in a min.