### PR TITLE
Disable 'Take a Selfie...' button in Upload Files dialog if not supported

### DIFF
--- a/src/extensions/default/UploadFiles/UploadFilesDialog.js
+++ b/src/extensions/default/UploadFiles/UploadFilesDialog.js
@@ -14,6 +14,14 @@ define(function (require, exports, module) {
 
     var dialogHTML     = require("text!htmlContent/upload-files-dialog.html");
 
+    // Not all browsers support access to camera
+    var isCameraSupported = (function(navigator) {
+        return !!(navigator.getUserMedia       ||
+                  navigator.webkitGetUserMedia ||
+                  navigator.mozGetUserMedia    ||
+                  navigator.msGetUserMedia);
+    }(window.navigator));
+
     function FileInput() {
         $(document.body)
             .append($('<input class="upload-files-input-elem" type="file" multiple />'));
@@ -48,6 +56,11 @@ define(function (require, exports, module) {
         var $takeSelfieButton = $dlg.find(".dialog-button[data-button-id='take-selfie']");
         var $cancelButton = $dlg.find(".dialog-button[data-button-id='cancel']");
         var $dropZoneDiv = $dlg.find(".drop-zone");
+
+        // Disable selfie button if not supported by browser
+        if(!isCameraSupported) {
+            $takeSelfieButton.attr("disabled", true);
+        }
 
         // Hide the uploadingFiles div until a drop event
         $uploadFilesDiv.hide();


### PR DESCRIPTION
The `Take a Selfie...` button isn't useful if the browser doesn't support it.  This adds a check, and disables it if it can't be used in the current browser.

Testing this in Safari is hilariously impossible, due to how broken our UI is there.  You can open the console and type `bramble.showUploadFilesDialog()` to get it to appear.