### PR TITLE
Deal with zip files that don't report folders before files within

### DIFF
--- a/src/utils/DragAndDrop.js
+++ b/src/utils/DragAndDrop.js
@@ -277,6 +277,7 @@ define(function (require, exports, module) {
         function handleRegularFile(deferred, file, filename, buffer, encoding) {
             file.write(buffer, {encoding: encoding}, function(err) {
                 if (err) {
+                    errorList.push({path: filename, error: "unable to write file: " + err.message || ""});
                     deferred.reject(err);
                     return;
                 }
@@ -295,6 +296,7 @@ define(function (require, exports, module) {
 
             unzip(buffer, function(err) {
                 if (err) {
+                    errorList.push({path: filename, error: "unable to unzip file: " + err.message || ""});
                     deferred.reject(err);
                     return;
                 }


### PR DESCRIPTION
If you try to unzip http://www.free-css.com/free-css-layouts/page1/css-layout-1#shout file in Brackets, it tries to write a file to a `layout1/` dir before the dir is created.  This patch fixes things so we can properly deal with zip files that aren't structured as expected.

I've also added proper error handling in the drag and drop code, since it silently failed before.