### PR TITLE
Fix https://github.com/mozilla/thimble.webmaker.org/issues/766

### DIFF
--- a/src/extensions/default/BrambleUrlCodeHints/camera/utils.js
+++ b/src/extensions/default/BrambleUrlCodeHints/camera/utils.js
@@ -21,9 +21,9 @@ define(function (require, exports, module) {
         return new Buffer(bytes.buffer);
     }
 
-    // Save the photo into the filesystem
+    // Save the photo into the filesystem as a binary file
     function persist(path, data, callback) {
-        fs.writeFile(path, data, callback);
+        fs.writeFile(path, data, {encoding: null}, callback);
     }
 
     exports.base64ToBuffer = base64ToBuffer;


### PR DESCRIPTION
In Firefox, we transfer ownership of data buffers when we `writeFile` across to the hosting app (i.e., via `MessageChannel.postMessage` and setting a `transferrable`).  In the previous code we were writing to disk and caching in parallel, and this meant that the data buffer would sometimes vanish and we'd end up writing an empty array of data, corrupting the image.  On refresh it would work, since the bytes on disk where really there, and would get read back and cached on reload.

The fix is to cache *before* we write/transfer the data.  I've also fixed some other small things with how we were doing options arguments, and repeated callback calls.