### PR TITLE
Add bramble.getRootDir() so a client can determine the mount path

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,6 +260,7 @@ a number of read-only getters are available in order to access state information
 * `getPreviewMode()` - returns one of `"mobile"` or `"desktop"`, depending on current preview mode
 * `getSidebarVisible()` - returns `true` or `false` depending on whether the sidebar (file tree) is visible
 * `getLayout()` - returns an `Object` with three integer properties: `sidebarWidth`, `firstPaneWidth`, `secondPaneWidth`.  The `firstPaneWidth` refers to the editor, where `secondPaneWidth` is the preview.
+* `getRootDir()` - returns the project root directory to which Bramble is mounted
 * `getTheme()` - returns the name of the current theme.
 * `getFontSize()` - returns the current font size as a string (e.g., `"12px"`).
 * `getWordWrap()` - returns the current word wrap setting as a `Boolean` (i.e., enabled or disabled).

--- a/src/bramble/client/main.js
+++ b/src/bramble/client/main.js
@@ -163,6 +163,9 @@ define([
         // State info for UI
         var _state = new StateManager(options.disableUIState);
 
+        // The project root dir that Bramble mounted
+        var _root;
+
         // Callback functions waiting for a postMessage from Bramble
         var _callbacks = {};
 
@@ -175,6 +178,7 @@ define([
         self.getTheme = function() { return _state.theme; };
         self.getFontSize = function() { return _state.fontSize; };
         self.getSidebarVisible = function() { return _state.sidebarVisible; };
+        self.getRootDir = function() { return _root; };
         self.getWordWrap = function() { return _state.wordWrap; };
         self.getTutorialExists = function() { return _tutorialExists; };
         self.getTutorialVisible = function() { return _tutorialVisible; };
@@ -363,7 +367,7 @@ define([
                     if (!stats.isDirectory()) {
                         setReadyState(Bramble.ERROR, new Error("mount path is not a directory: " + root));
                     } else {
-                        self.root = root;
+                        _root = root;
                         self.tutorialPath = Path.join(root, TUTORIAL_FILENAME);
 
                         // Check to see if we have a tutorial or not


### PR DESCRIPTION
I need this for https://github.com/mozilla/thimble.webmaker.org/issues/788 in order to strip the mount path off absolute file paths returned from bramble.