### PR TITLE
Rework startup logic so requirejs doesn't timeout, part of https://github.com/mozilla/thimble.webmaker.org/issues/777

### DIFF
--- a/src/extensions/default/bramble/lib/RemoteEvents.js
+++ b/src/extensions/default/bramble/lib/RemoteEvents.js
@@ -45,9 +45,6 @@ define(function (require, exports, module) {
     }
 
     function start() {
-        // Signal to the hosting app that we're ready to mount a filesystem
-        sendEvent({type: "bramble:readyToMount"});
-
         // Listen for layout changes. We currently consolidate start/end
         // events into one single "bramble:layout" event for the hosting app.
         BrambleEvents.on("bramble:updateLayoutStart", sendLayoutEvent);


### PR DESCRIPTION
This changes how the load ordering works by not blocking the extension loading on the remote mount message from the hosting app.  Instead, we load the app as fast as possible, but wait to load the project until we get a mount request.  This way, requirejs will have finished loading and won't timeout if the time between `Bramble.load()` and `Bramble.mount()` is long.

I've also simplified the project loading a bit, since we don't care about a bunch of the cases that desktop Brackets does.