### PR TITLE
Fix Thimble Issue 861: format filesystem if it's corrupt

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,29 @@ var fs = Bramble.getFileSystem();
 This `fs` instance can be used to setup the filesystem for the Bramble editor prior to
 loading.  You can access things like `Path` and `Buffer` via `Bramble.Filer.*`.
 
+## Bramble.formatFileSystem(callback)
+
+WARNING: this **will** destroy data, and is meant to be used in the case that
+the filesystem is corrupted (`err.code === "EFILESYSTEMERROR"`), or for when an
+app wants to allow a user to wipe their disk.
+
+```js
+Bramble.on("error", function(err) {
+  if(err.code === "EFILESYSTEMERROR") {
+    Bramble.formatFileSystem(function(err) {
+      if(err) {
+        // Unable to create filesystem, fatal (and highly unlikely) error
+      } else {
+        // filesystem is now clean and empty, use Bramble.getFileSystem() to obtain instance
+      }
+    });
+  }
+});
+```
+
+NOTE: you can turn this recovery behaviour on automatically by passing `autoRecoverFileSystem: true`
+in the options to `Bramble.load()`.
+
 ## Bramble.load(elem[, options])
 
 Once you have a reference to the `Bramble` object, you use it to starting loading the editor:
@@ -210,6 +233,7 @@ The `options` object allows you to configure Bramble:
      * `disable`: `<Array(String)>` a list of extensions to disable
  * `hideUntilReady`: `<Boolean>` whether to hide Bramble until it's fully loaded.
  * `disableUIState`: `<Boolean>` by default, UI state is kept between sessions.  This disables it (and clears old values), and uses the defaults from Bramble.
+ * `autoRecoverFileSystem`: `<Boolean>` whether to try and autorecover the filesystem on failure (see `Bramble.formatFileSystem` above).
  * `debug`: `<Boolean>` whether to log debug info.
 
 ## Bramble.mount(root[, filename])


### PR DESCRIPTION
Based on what is happening in https://github.com/mozilla/thimble.webmaker.org/issues/861, getting an `EFILESYSTEMERROR` means that the provider either couldn't open the db, or the data was corrupt, or we couldn't find the root node.  In any case, the data in the filesystem is now corrupt, and the only real remedy is to format the disk and start again.

My patch isn't quite right yet, because it only replaces `_fs` internally, so you'd have to call `getFileSystem()` again to get the proper reference.  Should we bring up an alert telling you the page needs to be refreshed to recover?  Should we make `getFileSystem()` async, so that it always you a working fs, or an error if that's not possible?  Should we move the `fs` getter onto `bramble` vs. `Bramble`, so you have to call `load()` first, which is async?