### PR TITLE
Fix #427 - Code using Path.extname() should deal with lower vs. uppercase

### DIFF
--- a/src/filesystem/impls/filer/lib/content.js
+++ b/src/filesystem/impls/filer/lib/content.js
@@ -6,7 +6,7 @@ define(function (require, exports, module) {
     var LanguageManager = require('language/LanguageManager');
 
     function _getLanguageId(ext) {
-        ext = ext.replace(/^\./, "");
+        ext = ext.replace(/^\./, "").toLowerCase();
         var language = LanguageManager.getLanguageForExtension(ext);
         return language ? language.getId() : "";
     }
@@ -33,6 +33,8 @@ define(function (require, exports, module) {
         },
 
         mimeFromExt: function(ext) {
+            ext = ext.toLowerCase();
+
             switch(ext) {
             case '.html':
             case '.htmls':

--- a/src/utils/DragAndDrop.js
+++ b/src/utils/DragAndDrop.js
@@ -266,12 +266,7 @@ define(function (require, exports, module) {
         }
 
         function shouldOpenFile(filename, encoding) {
-            var ext = Path.extname(filename).replace(/^\./, "");
-            var language = LanguageManager.getLanguageForExtension(ext);
-            var id = language && language.getId();
-            var isImage = id === "image" || id === "svg";
-
-            return isImage || encoding === "utf8";
+            return Content.isImage(Path.extname(filename)) || encoding === "utf8";
         }
 
         function handleRegularFile(deferred, file, filename, buffer, encoding) {
@@ -338,7 +333,7 @@ define(function (require, exports, module) {
 
             // If we don't know about this language type, or the OS doesn't think
             // it's text, reject it.
-            var ext = Path.extname(item.name).replace(/^\./, "");
+            var ext = Path.extname(item.name).replace(/^\./, "").toLowerCase();
             var languageIsSupported = !!LanguageManager.getLanguageForExtension(ext);
             var typeIsText = Content.isTextType(item.type);
 
@@ -402,11 +397,12 @@ define(function (require, exports, module) {
 
                 var filename = Path.join(StartupState.project("root"), item.name);
                 var file = FileSystem.getFileForPath(filename);
+                var ext = Path.extname(filename).toLowerCase();
 
                 // Create a Filer Buffer, and determine the proper encoding. We
                 // use the extension, and also the OS provided mime type for clues.
                 var buffer = new Filer.Buffer(e.target.result);
-                var utf8FromExt = Content.isUTF8Encoded(Path.extname(filename));
+                var utf8FromExt = Content.isUTF8Encoded(ext);
                 var utf8FromOS = Content.isTextType(item.type);
                 var encoding =  utf8FromExt || utf8FromOS ? 'utf8' : null;
                 if(encoding === 'utf8') {
@@ -414,9 +410,9 @@ define(function (require, exports, module) {
                 }
 
                 // Special-case .zip files, so we can offer to extract the contents
-                if(Path.extname(filename) === ".zip") {
+                if(ext === ".zip") {
                     handleZipFile(deferred, file, filename, buffer, encoding);
-                } else if(Path.extname(filename) === ".tar") {
+                } else if(ext === ".tar") {
                     handleTarFile(deferred, file, filename, buffer, encoding);
                 } else {
                     handleRegularFile(deferred, file, filename, buffer, encoding);


### PR DESCRIPTION
This works now for me with files named `.zip` or `.ZIP`, same with `.tar` and `.TAR`, and I've also dealt with other cases where we have a file like `.CSS` and should probably treat it as `.css`