### PR TITLE
Fix https://github.com/mozilla/thimble.webmaker.org/issues/885

### DIFF
--- a/src/styles/bramble_overrides.css
+++ b/src/styles/bramble_overrides.css
@@ -14,3 +14,8 @@
 li.jstree-leaf > a {
 	cursor: pointer !important;
 }
+
+/* Add extra space to the left of the cursor in order that it will show at pos 0 */
+.CodeMirror-sizer {
+	margin-left: 75px !important;
+}


### PR DESCRIPTION
This increases `.CodeMirror-sizer`'s `margin-left` by `3px` in order to accomodate our larger font size, and always show the cursor at index 0 in the line.

![screenshot 2015-08-18 19 57 12](https://cloud.githubusercontent.com/assets/427398/9345867/7389d9a0-45e3-11e5-8c62-f1b657fe2cff.png)
