### PR TITLE
Fixed #408 - Add a production branch for auto prod deploys

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,18 +8,31 @@ before_script:
 branches:
   only:
   - bramble
+  - production
 notifications:
   irc: "irc.mozilla.org#thimble"
 deploy:
-  provider: s3
-  access_key_id: AKIAJZZYAKJA33TQEHLA
-  secret_access_key:
-    secure: PUmptcr3naHfuC1FU8q7F3OEbnbCzfKaTYleJDpYjz7lSt24zoXD5epaTcusva4SafMS3I5NeKZ79YmDrn2ONEyLdyPCLKNScOFEClhjFNeuMOrf63fK3MO1RwNtJ2Rvjwwi2k+/pVaVUXKcr287JWywDZUZfYp7DjxJdNU6JZ0=
-  bucket: mozillathimblelivepreview.net
-  local-dir: dist
-  upload-dir: bramble/dist
-  skip_cleanup: true
-  detect_encoding: true
-  on:
-    repo: humphd/brackets
-    branch: bramble
+  - provider: s3
+    access_key_id: AKIAJZZYAKJA33TQEHLA
+    secret_access_key:
+      secure: PUmptcr3naHfuC1FU8q7F3OEbnbCzfKaTYleJDpYjz7lSt24zoXD5epaTcusva4SafMS3I5NeKZ79YmDrn2ONEyLdyPCLKNScOFEClhjFNeuMOrf63fK3MO1RwNtJ2Rvjwwi2k+/pVaVUXKcr287JWywDZUZfYp7DjxJdNU6JZ0=
+    bucket: mozillathimblelivepreview.net
+    local-dir: dist
+    upload-dir: bramblestaging/dist
+    skip_cleanup: true
+    detect_encoding: true
+    on:
+      repo: humphd/brackets
+      branch: bramble
+  - provider: s3
+    access_key_id: AKIAJZZYAKJA33TQEHLA
+    secret_access_key:
+      secure: PUmptcr3naHfuC1FU8q7F3OEbnbCzfKaTYleJDpYjz7lSt24zoXD5epaTcusva4SafMS3I5NeKZ79YmDrn2ONEyLdyPCLKNScOFEClhjFNeuMOrf63fK3MO1RwNtJ2Rvjwwi2k+/pVaVUXKcr287JWywDZUZfYp7DjxJdNU6JZ0=
+    bucket: mozillathimblelivepreview.net
+    local-dir: dist
+    upload-dir: bramble/dist
+    skip_cleanup: true
+    detect_encoding: true
+    on:
+      repo: humphd/brackets
+      branch: production

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,3 +1,9 @@
+# Bramble
+
+### Deployment
+
+Anything merged into the branch `bramble` will be automatically deployed to staging. To deploy to production, push changes to the `production` branch.
+
 # The Basics
 
 ### Filing a bug


### PR DESCRIPTION
Part of this change is splitting the bucket we used to serve brackets resources in two.

Before, we had a folder called `bramble/dist` which contained the staging version of brackets.

Now, `bramble/dist` will be the production folder and `bramblestaging/dist` will be the staging one.

I've included readme updates for how to deploy to production.