### PR TITLE
Brackets portion of fix for Thimble issue 896, plus fix for theme state

### DIFF
--- a/src/extensions/default/bramble/lib/PostMessageTransport.js
+++ b/src/extensions/default/bramble/lib/PostMessageTransport.js
@@ -175,7 +175,14 @@ define(function (require, exports, module) {
     function reload() {
         var launcher = Launcher.getCurrentInstance();
         var liveDoc = LiveDevMultiBrowser._getCurrentLiveDoc();
-        var url = BlobUtils.getUrl(liveDoc.doc.file.fullPath);
+        var url;
+
+        // Don't go any further if we don't have a live doc yet (nothing to reload)
+        if(!liveDoc) {
+            return;
+        }
+
+        url = BlobUtils.getUrl(liveDoc.doc.file.fullPath);
 
         // Don't start rewriting a URL if it's already in process (prevents infinite loop)
         if(_pendingReloadUrl === url) {

--- a/src/extensions/default/bramble/lib/Theme.js
+++ b/src/extensions/default/bramble/lib/Theme.js
@@ -6,7 +6,7 @@ define(function (require, exports, module) {
     "use strict";
 
     var ThemeManager     = brackets.getModule("view/ThemeManager");
-    var ThemePreferences = brackets
+    var prefs            = brackets
                             .getModule("preferences/PreferencesManager")
                             .getExtensionPrefs("themes");
 
@@ -15,23 +15,18 @@ define(function (require, exports, module) {
     var themePath        = Path.join(basePath, 'extensions/default/bramble/stylesheets');
     var BrambleEvents    = brackets.getModule("bramble/BrambleEvents");
 
-    // Store the current theme, and load defaults as if
-    // they were third party themes
-    var currentTheme = 'light-theme';
-
     function toggle(data) {
-        var theme = data.theme || currentTheme;
+        var theme = data.theme || getTheme();
         setTheme(theme === "light-theme" ? "dark-theme" : "light-theme");
     }
 
     function setTheme(theme) {
-        currentTheme = theme;
-        ThemePreferences.set("theme", theme);
+        prefs.set("theme", theme);
         BrambleEvents.triggerThemeChange(theme);
     }
 
     function getTheme() {
-        return currentTheme;
+        return prefs.get("theme");
     }
 
     function init(theme) {
@@ -57,8 +52,12 @@ define(function (require, exports, module) {
         ThemeManager.addTheme(lightFile, lightOptions);
         ThemeManager.addTheme(darkFile, darkOptions);
 
-        currentTheme = theme === 'light-theme' ? "dark-theme" : "light-theme";
-        ThemePreferences.set("theme", currentTheme);
+        // We support only light-theme and dark-theme, with a default of dark-theme
+        if(!(theme === "light-theme" || theme === "dark-theme")) {
+            theme = "dark-theme";
+        }
+
+        prefs.set("theme", theme);
     }
 
     module.exports.toggle = toggle;

--- a/src/extensions/default/bramble/lib/UI.js
+++ b/src/extensions/default/bramble/lib/UI.js
@@ -50,6 +50,7 @@ define(function (require, exports, module) {
                     }
                 }
 
+                // Restore any UI defaults cached in the client
                 restoreState();
 
                 // Show the editor, remove spinner
@@ -65,26 +66,18 @@ define(function (require, exports, module) {
      * Restores user state sent from the hosting app
      */
     function restoreState() {
-        var theme = BrambleStartupState.ui("theme");
-        if(theme) {
-            switch(theme) {
-            case "light-theme":
-            case "dark-theme":
-                Theme.setTheme(theme);
-                break;
-            default:
-                console.warn("[Bramble] unknown theme: `" + theme + "`");
-            }
-        }
+        // Load the two theme extensions outside of
+        // the ExtensionLoader logic (avoids circular dependencies)
+        Theme.init(BrambleStartupState.ui("theme"));
 
         var previewMode = BrambleStartupState.ui("previewMode");
         if(previewMode) {
             switch(previewMode) {
             case "desktop":
-                showDesktopView();
+                showDesktopView(true);
                 break;
             case "mobile":
-                showMobileView();
+                showMobileView(true);
                 break;
             default:
                 console.warn("[Bramble] unknown preview mode: `" + previewMode + "`");
@@ -202,7 +195,7 @@ define(function (require, exports, module) {
         MainViewManager.setActivePaneId("first-pane");
     }
 
-    function showDesktopView() {
+    function showDesktopView(preventReload) {
         if(!isMobileViewOpen) {
             return;
         }
@@ -221,10 +214,13 @@ define(function (require, exports, module) {
 
         isMobileViewOpen = false;
         BrambleEvents.triggerPreviewModeChange("desktop");
-        PostMessageTransport.reload();
+
+        if(!preventReload) {
+            PostMessageTransport.reload();
+        }
     }
 
-    function showMobileView() {
+    function showMobileView(preventReload) {
         if(isMobileViewOpen) {
             return;
         }
@@ -247,7 +243,10 @@ define(function (require, exports, module) {
 
         isMobileViewOpen = true;
         BrambleEvents.triggerPreviewModeChange("mobile");
-        PostMessageTransport.reload();
+
+        if(!preventReload) {
+            PostMessageTransport.reload();
+        }
     }
 
     /**

--- a/src/extensions/default/bramble/main.js
+++ b/src/extensions/default/bramble/main.js
@@ -104,14 +104,6 @@ define(function (require, exports, module) {
             console.warn("Unable to preload filesystem URLs", err);
         }
 
-        // Load the two theme extensions outside of
-        // the ExtensionLoader logic (avoids circular dependencies)
-        Theme.init();
-
-        // Setup the iframe browser and Blob URL live dev servers and
-        // load the initial document into the preview.
-        startLiveDev();
-
         // Below are methods to change the preferences of brackets, more available at:
         // https://github.com/adobe/brackets/wiki/How-to-Use-Brackets#list-of-supported-preferences
         PreferencesManager.set("insertHintOnTab", true);
@@ -170,6 +162,10 @@ define(function (require, exports, module) {
 
                     // Signal that Brackets is loaded
                     AppInit._dispatchReady(AppInit.APP_READY);
+
+                    // Setup the iframe browser and Blob URL live dev servers and
+                    // load the initial document into the preview.
+                    startLiveDev();
 
                     UI.initUI(finishStartup);
                 });


### PR DESCRIPTION
This deals with the Bracket's side of https://github.com/mozilla/thimble.webmaker.org/issues/896, and, since it's related, fixes the issues around themes not being remembered (I'll find/close these after we land this).  I still need a small fix in Thimble for this, so we don't double-set the Theme on startup.  Basically what this does is change the load order so that we start live dev before we try and do anything related to the iframe browser.