### PR TITLE
Fix #439: phone-wrapper should extend 100% of the available height

### DIFF
--- a/src/extensions/default/bramble/stylesheets/style.css
+++ b/src/extensions/default/bramble/stylesheets/style.css
@@ -46,6 +46,7 @@
 .phone-wrapper {
     background: #eaeaea;
     padding: 30px 0;
+    height: 100%;
 }
 
 .phone-container {


### PR DESCRIPTION
Here's what it looks like now:

![screenshot 2015-08-25 10 47 57](https://cloud.githubusercontent.com/assets/427398/9469949/9f5a7c04-4b17-11e5-8cd5-69ca228e0f11.png)
