### PR TITLE
Remove file conflict dialog's Save As... button, since we don't need it

### DIFF
--- a/src/document/DocumentCommandHandlers.js
+++ b/src/document/DocumentCommandHandlers.js
@@ -738,11 +738,15 @@ define(function (require, exports, module) {
                     StringUtils.breakableUrl(docToSave.file.fullPath)
                 ),
                 [
+                    /**
+                     XXXBramble: we don't currently ship File > Save As... dialog, so remove for now.
+                     If you need dialogs, see https://github.com/ScottDowne/filer-dialogs
                     {
                         className : Dialogs.DIALOG_BTN_CLASS_LEFT,
                         id        : Dialogs.DIALOG_BTN_SAVE_AS,
                         text      : Strings.SAVE_AS
                     },
+                    **/
                     {
                         className : Dialogs.DIALOG_BTN_CLASS_NORMAL,
                         id        : Dialogs.DIALOG_BTN_CANCEL,


### PR DESCRIPTION
This improves the UX of the file conflict dialog, but removing the option to `Save As...` a conflicted file.  Now you either overwrite what's on disk, or cancel the save.