### PR TITLE
Update bramble.addNewFile() to take more options, replacing addNewFileWithContents

### DIFF
--- a/README.md
+++ b/README.md
@@ -313,8 +313,7 @@ to be notified when the action completes:
 * `showTutorial([callback])` - shows tutorial (i.e., tutorial.html) vs editor contents in preview
 * `hideTutorial([callback])` - stops showing tutorial (i.e., tutorial.html) and uses editor contents in preview
 * `showUploadFilesDialog([callback])` - shows the Upload Files dialog, allowing users to drag-and-drop, upload a file, or take a selfie.
-* `addNewFile([ext, callback])` - adds a new file, using the optional `ext` as an extension if provided.
-* `addNewFileWithContents(filename, contents[, callback])` - adds a new file to the mounted project's root dir with the given `filename` and `contents` (`Filer.Buffer` or `String`).
+* `addNewFile([options, callback])` - adds a new file, using the provided options, which can include: `filename` a `String` with the complete filename to use; `contents` a `Filer.Buffer` or `String` with the new file's data; `ext` a `String` with the new file's extension; `basenamePrefix` a `String` with the basename to use when generating a new filename.  NOTE: if you provide `filename`, `basenamePrefix` and `ext` are ignored.
 * `addNewFolder([callback])` - adds a new folder.
 * `export([callback])` - creates an archive `.zip` file of the entire project's filesystem, and downloads it to the browser.
 

--- a/src/bramble/client/main.js
+++ b/src/bramble/client/main.js
@@ -681,27 +681,19 @@ define([
         this._executeRemoteCommand({commandCategory: "bramble", command: "BRAMBLE_SHOW_UPLOAD_FILES_DIALOG"}, callback);
     };
 
-    BrambleProxy.prototype.addNewFile = function(ext, callback) {
-        if(ext) {
-            this._executeRemoteCommand({commandCategory: "bramble", command: "BRAMBLE_ADD_NEW_FILE", args: ext}, callback);
-        } else {
-            this._executeRemoteCommand({commandCategory: "brackets", command: "FILE_NEW"}, callback);
-        }
-    };
-
-    BrambleProxy.prototype.addNewFileWithContents = function(filename, contents, callback) {
-        // Always send a buffer
-        if(typeof(contents) === "string") {
-            contents = new FilerBuffer(contents, "utf8");
+    BrambleProxy.prototype.addNewFile = function(options, callback) {
+        // Always use a buffer if we send contents
+        if(typeof(options.contents) === "string") {
+            options.contents = new FilerBuffer(options.contents, "utf8");
         }
 
-        // Serialize to a regular array
-        contents = contents.toJSON().data;
+        // Serialize buffer to a regular array
+        options.contents = options.contents.toJSON().data;
 
         this._executeRemoteCommand({
             commandCategory: "bramble",
-            command: "BRAMBLE_ADD_NEW_FILE_WITH_CONTENTS",
-            args: [filename, contents]
+            command: "BRAMBLE_ADD_NEW_FILE",
+            args: [options]
         }, callback);
     };
 

--- a/src/extensions/default/bramble/lib/RemoteCommandHandler.js
+++ b/src/extensions/default/bramble/lib/RemoteCommandHandler.js
@@ -14,11 +14,7 @@ define(function (require, exports, module) {
     var BrambleEvents      = brackets.getModule("bramble/BrambleEvents");
     var PreferencesManager = brackets.getModule("preferences/PreferencesManager");
     var _                  = brackets.getModule("thirdparty/lodash");
-    var BracketsFiler      = brackets.getModule("filesystem/impls/filer/BracketsFiler");
     var ArchiveUtils       = brackets.getModule("filesystem/impls/filer/ArchiveUtils");
-    var Path               = BracketsFiler.Path;
-    var FilerBuffer        = BracketsFiler.Buffer;
-    var StartupState       = brackets.getModule("bramble/StartupState");
 
     var PostMessageTransport = require("lib/PostMessageTransport");
     var Tutorial = require("lib/Tutorial");
@@ -123,30 +119,7 @@ define(function (require, exports, module) {
             break;
         case "BRAMBLE_ADD_NEW_FILE":
             skipCallback = true;
-            CommandManager.execute("bramble.addFileWithType", args[0]).always(callback);
-            break;
-        case "BRAMBLE_ADD_NEW_FILE_WITH_CONTENTS":
-            skipCallback = true;
-            // Add the new file to the project root, refresh the file tree, and open.
-            args[0] = Path.join(StartupState.project("root"), args[0]);
-            BracketsFiler.fs().writeFile(
-                args[0],
-                new FilerBuffer(args[1]),
-                {encoding: null},
-                function(err) {
-                    if(err) {
-                        return callback(err);
-                    }
-
-                    CommandManager.execute(Commands.FILE_REFRESH)
-                        .always(function() {
-                            CommandManager.execute(
-                                Commands.CMD_ADD_TO_WORKINGSET_AND_OPEN,
-                                {fullPath: args[0]}
-                            ).always(callback);
-                        });
-                }
-            );
+            CommandManager.execute("bramble.addFile", args[0]).always(callback);
             break;
         case "BRAMBLE_EXPORT":
             skipCallback = true;


### PR DESCRIPTION
This makes it possible for a client to control how `addNewFile` works more exactly, providing filename portions and contents.