### PR TITLE
Fix https://github.com/mozilla/thimble.webmaker.org/issues/956 - remember preview scroll position

### DIFF
--- a/src/extensions/default/bramble/lib/PostMessageTransport.js
+++ b/src/extensions/default/bramble/lib/PostMessageTransport.js
@@ -21,6 +21,7 @@ define(function (require, exports, module) {
     // The script that will be injected into the previewed HTML to handle the other side of the post message connection.
     var PostMessageTransportRemote = require("text!lib/PostMessageTransportRemote.js");
     var Tutorial = require("lib/Tutorial");
+    var ScrollManager = require("lib/ScrollManager");
 
     // An XHR shim will be injected as well to allow XHR to the file system
     var XHRShim = require("text!lib/xhr/XHRShim.js");
@@ -164,9 +165,16 @@ define(function (require, exports, module) {
      * @return {string}
      */
     function getRemoteScript() {
+        var currentDoc = LiveDevMultiBrowser._getCurrentLiveDoc();
+        var currentPath;
+        if(currentDoc) {
+            currentPath = currentDoc.doc.file.fullPath;
+        }
+
         return '<base href="' + window.location.href + '">\n' +
             "<script>\n" + PostMessageTransportRemote + "</script>\n" +
-            "<script>\n" + XHRShim + "</script>\n";
+            "<script>\n" + XHRShim + "</script>\n" +
+            ScrollManager.getRemoteScript(currentPath);
     }
 
     // URL of document being rewritten/launched (if any)

--- a/src/extensions/default/bramble/lib/ScrollManager.js
+++ b/src/extensions/default/bramble/lib/ScrollManager.js
@@ -1,0 +1,15 @@
+define(function (require, exports, module) {
+    "use strict";
+
+    var ScrollManagerRemote = require("text!lib/ScrollManagerRemote.js");
+
+    function getRemoteScript(filename) {
+        filename = filename || "unknown";
+
+        // Track scroll position per filename, so you can be at different points in each doc
+        return "<script>window.___brambleFilename = '" + filename + "';</script>\n" +
+               "<script>\n" + ScrollManagerRemote + "</script>\n";
+    }
+
+    exports.getRemoteScript = getRemoteScript;
+});

--- a/src/extensions/default/bramble/lib/ScrollManagerRemote.js
+++ b/src/extensions/default/bramble/lib/ScrollManagerRemote.js
@@ -1,0 +1,17 @@
+/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, forin: true, maxerr: 50, regexp: true, bitwise: true */
+/* global addEventListener, sessionStorage */
+(function() {
+    "use strict";
+
+    var SCROLL_KEY = "___bramble-preview-scrollTop::" + window.___brambleFilename;
+
+    // Retore last scroll position for this session (if any)
+    addEventListener("DOMContentLoaded", function() {
+        document.body.scrollTop = sessionStorage.getItem(SCROLL_KEY)|0;
+    }, false);
+
+    // Remember last scroll position for this document
+    addEventListener("scroll", function() {
+        sessionStorage.setItem(SCROLL_KEY, document.body.scrollTop);
+    }, false);
+}());

--- a/src/extensions/default/bramble/lib/Tutorial.js
+++ b/src/extensions/default/bramble/lib/Tutorial.js
@@ -39,7 +39,7 @@ define(function (require, exports, module) {
         return _tutorialOverride;
     }
 
-    function getUrl() {
+    function getPath() {
         return Path.join(StartupState.project("root"), "tutorial.html");
     }
 
@@ -47,7 +47,7 @@ define(function (require, exports, module) {
      * Callback returns `true` or `false`, like fs.exists().
      */
     function exists(callback) {
-        Filer.fs().stat(getUrl(), function(err, stats) {
+        Filer.fs().stat(getPath(), function(err, stats) {
             callback(stats && stats.type === "FILE");
         });
     }
@@ -61,7 +61,7 @@ define(function (require, exports, module) {
             return false;
         }
 
-        return getUrl() === editor.document.file.fullPath;
+        return getPath() === editor.document.file.fullPath;
     }
 
     /**
@@ -89,7 +89,7 @@ define(function (require, exports, module) {
 
     exports.setOverride = setOverride;
     exports.getOverride = getOverride;
-    exports.getUrl = getUrl;
+    exports.getPath = getPath;
     exports.exists = exists;
     exports.shouldReload = shouldReload;
     exports.shouldPostMessage = shouldPostMessage;

--- a/src/extensions/default/bramble/lib/launcher.js
+++ b/src/extensions/default/bramble/lib/launcher.js
@@ -68,7 +68,7 @@ define(function (require, exports, module) {
                 // Swap out the tutorial url and reload if necessary. We try hard
                 // not to reload unless we have to, so the tutorial doesn't flicker.
                 if(Tutorial.shouldReload()) {
-                    _launch(Tutorial.getUrl(), callback);
+                    _launch(Tutorial.getPath(), callback);
                 }
             }
         });

--- a/src/extensions/default/bramble/nohost/HTMLServer.js
+++ b/src/extensions/default/bramble/nohost/HTMLServer.js
@@ -10,8 +10,10 @@ define(function (require, exports, module) {
         Filer                   = brackets.getModule("filesystem/impls/filer/BracketsFiler"),
         Path                    = Filer.Path,
         HTMLRewriter            = brackets.getModule("filesystem/impls/filer/lib/HTMLRewriter"),
-        CSSRewriter             = brackets.getModule("filesystem/impls/filer/lib/CSSRewriter"),
-        Compatibility           = require("lib/compatibility");
+        CSSRewriter             = brackets.getModule("filesystem/impls/filer/lib/CSSRewriter");
+
+    var Compatibility           = require("lib/compatibility"),
+        ScrollManager           = require("lib/ScrollManager");
 
     var fs = Filer.fs(),
         _shouldUseBlobURL;
@@ -145,6 +147,9 @@ define(function (require, exports, module) {
                     return callback(err);
                 }
 
+                // Since we're not instrumenting this doc fully for some reason,
+                // at least inject the scroll manager so we can track scroll position.
+                body = body.replace(/<\/\s*head>/, ScrollManager.getRemoteScript(path) + "$&");
                 serve(body);
             });
         }


### PR DESCRIPTION
This causes the preview to remember and restore the vertical scroll position for every page that loads in the preview, keeping track of the position per file, so that you can be in different positions for each one.  It uses `sessionStorage` vs. `localStorage` so that it will be recovered if you refresh, but not affect other open Bramble tabs.  This will work for regular files and the tutorial, and switching back and forth between Preview and Tutorial mode will remember your place in both.

This bug was really bothering @flukeout last week, so I think we should try and ship this if it's safe.  Can I get some testing and review from all of you @flukeout, @gideonthomas, @sedge at some point?  A good test would be to open one of the longer starter makes (make sure it will scroll, the KEEP CALM poster is useless):

* Open the `index.html`, scroll to mid-way
* Click `Tutorial`, and scroll the page half way
* Click back to `Preview`, confirm you're still in the right spot, scroll a bit more
* Click back to `Tutorial` check your position, etc.

I'm finding that this makes the app feel 100% more usable.