### PR TITLE
Deal with IE throwing 'Access Denied' error (-2147024891) when accessing stylesheet properties

### DIFF
--- a/src/LiveDevelopment/MultiBrowserImpl/protocol/remote/DocumentObserver.js
+++ b/src/LiveDevelopment/MultiBrowserImpl/protocol/remote/DocumentObserver.js
@@ -68,10 +68,11 @@
 
             // Deal with Firefox's SecurityError when accessing sheets
             // from other domains. Chrome will safely return `undefined`.
+            // IE gives an "Access Denied" error (-2147024891), which we also need to catch.
             try {
                 cssRules = sheet.cssRules;
             } catch (e) {
-                if (e.name !== "SecurityError") {
+                if (!(e.name === "SecurityError" || e.number === -2147024891)) {
                     throw e;
                 }
             }


### PR DESCRIPTION
Same sort of fix we had to do with Firefox, but IE does the error differently.