### PR TITLE
Brackets portion of https://github.com/mozilla/thimble.webmaker.org/issues/1031, better errors for failed fs operations

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,11 @@ Bramble.on("readyStateChange", function(previous, current) {
 });
 ```
 
+NOTE: in some browsers (e.g., Firefox) when the user is in "Private Browsing"
+mode, the filesystem (i.e., IndexedDB) will be inaccessible, and an error
+will be sent via the `error` event (i.e., `err.code === "EFILESYSTEMERROR"`).  This
+is the same error that occurs when the filesystem is corrupt (see `autoRecoverFileSystem` below).
+
 ## Bramble.getFileSystem()
 
 The FileSystem is owned by the hosting application, and can be obtained at any time by calling:

--- a/src/hosted.js
+++ b/src/hosted.js
@@ -105,8 +105,9 @@
             window.bramble = bramble;
         });
 
-        Bramble.on("error", function(e, err) {
-            console.log("Bramble error", err);
+        Bramble.once("error", function(err) {
+            console.error("Bramble error", err);
+            alert("Fatal Error: " + err.message + ". If you're in Private Browsing mode, data can't be written.");
         });
 
         Bramble.on("readyStateChange", function(previous, current) {


### PR DESCRIPTION
This tries to do a better job of failing fast when a filesystem operation comes back with `EFILESYSTEMERROR`.  It's actually impossible to catch this error the proper way, but later queued fs calls will get it.

I have a small fix to Thimble that's based on this.

NOTE: you can't auto recover the filesystem and deal with warning users in private browsing mode, since the recovery will also fail.  There's no solid way to deal with private browsing mode and Firefox. 