### PR TITLE
Mobile preview background color fixes.

### DIFF
--- a/src/extensions/default/bramble/stylesheets/style.css
+++ b/src/extensions/default/bramble/stylesheets/style.css
@@ -30,11 +30,12 @@
 }
 
 #second-pane {
-    background: white !important;
+    background: white;
 }
 
-.second-pane-scroll {
-    overflow: scroll !important;
+#second-pane.second-pane-scroll {
+    overflow: auto;
+    background: #eaeaea;
 }
 
 .expandEditor {
@@ -44,7 +45,6 @@
 
 /* Mobile view start */
 .phone-wrapper {
-    background: #eaeaea;
     padding: 30px 0;
 }
 


### PR DESCRIPTION
This makes it so that:
* Background behind phone in mobile preview is grey when the preview area is taller and shorter than the preview phone
* The scrollbars on the mobile preview area appear only when the phone is too tall to fit