### PR TITLE
Add CORS to dev server instance so we can serve dist/bramble.js to Thimble locally

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "scripts": {
         "postinstall": "grunt install",
         "test": "grunt test && grunt build-browser-compressed",
-        "start": "http-server -p 8000"
+        "start": "http-server -p 8000 --cors"
     },
     "license": "MIT"
 }


### PR DESCRIPTION
I needed this when I was debugging with Windows, so that it would allow the cross-origin load of `bramble.js`