### PR TITLE
Fix https://github.com/mozilla/thimble.webmaker.org/issues/1043 - fix style attribute parsing in HTMLRewriter

### DIFF
--- a/src/filesystem/impls/filer/lib/HTMLRewriter.js
+++ b/src/filesystem/impls/filer/lib/HTMLRewriter.js
@@ -81,7 +81,7 @@ define(function (require, exports, module) {
         var elements = this.doc.querySelectorAll("[style]");
 
         Async.eachSeries(elements, function(element, callback) {
-            var content = element.innerHTML;
+            var content = element.getAttribute("style");
             if(!content) {
                 return callback();
             }


### PR DESCRIPTION
Oh, to have unit tests and not regress this stuff!

This is a simple fix.