### PR TITLE
Fix #447 - support rewriting of <a href=...> dynamically via injected click handler

### DIFF
--- a/src/extensions/default/bramble/lib/LinkManager.js
+++ b/src/extensions/default/bramble/lib/LinkManager.js
@@ -1,0 +1,60 @@
+define(function (require, exports, module) {
+    "use strict";
+
+    var LiveDevMultiBrowser = brackets.getModule("LiveDevelopment/LiveDevMultiBrowser");
+    var Path                = brackets.getModule("filesystem/impls/filer/BracketsFiler").Path;
+    var CommandManager      = brackets.getModule("command/CommandManager");
+    var Commands            = brackets.getModule("command/Commands");
+    var FileSystem          = brackets.getModule("filesystem/FileSystem");
+
+    var Launcher = require("lib/launcher");
+    var LinkManagerRemote = require("text!lib/LinkManagerRemote.js");
+
+    function getRemoteScript() {
+        // Intercept clicks on <a> in the preview document
+        return "<script>\n" + LinkManagerRemote + "</script>\n";
+    }
+
+    function getNavigationPath(message) {
+        var match = message.match(/^bramble-navigate\:(.+)/);
+        return match && match[1];
+    }
+
+    // Whether or not this message is a navigation request from the LinkManagerRemote script.
+    function isNavigationRequest(message) {
+        return !!getNavigationPath(message);
+    }
+
+    // Attempt to navigate the preview and editor to a new path
+    function navigate(message) {
+        var path = getNavigationPath(message);
+        if(!path) {
+            return;
+        }
+
+        var currentDoc = LiveDevMultiBrowser._getCurrentLiveDoc();
+        if(!currentDoc) {
+            return;
+        }
+
+        var currentDir = Path.dirname(currentDoc.doc.file.fullPath);
+        path = Path.resolve(currentDir, path);
+
+        // Open it in the preview
+        var launcher = Launcher.getCurrentInstance();
+        launcher.launch(path);
+
+        // Open it in the editor
+        FileSystem.resolve(path, function(err, file) {
+            if(err) {
+                console.log("[Bramble Error] unable to open path in editor", path, err);
+                return;
+            }
+            CommandManager.execute(Commands.CMD_ADD_TO_WORKINGSET_AND_OPEN, { fullPath: file.fullPath });
+        });
+    }
+
+    exports.getRemoteScript = getRemoteScript;
+    exports.isNavigationRequest = isNavigationRequest;
+    exports.navigate = navigate;
+});

--- a/src/extensions/default/bramble/lib/LinkManagerRemote.js
+++ b/src/extensions/default/bramble/lib/LinkManagerRemote.js
@@ -1,0 +1,28 @@
+/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, forin: true, maxerr: 50, regexp: true, bitwise: true */
+/* global addEventListener, window */
+(function() {
+    "use strict";
+
+    function handleClick(e) {
+        var url = e.target.getAttribute("href");
+
+        // For local paths vs. absolute URLs, try to open the right file
+        if(!(/\:?\/\//.test(url)) && window._Brackets_LiveDev_Transport) {
+            window._Brackets_LiveDev_Transport.send("bramble-navigate:" + url);
+        } else {
+            window.open(url, "_blank");
+        }
+
+        return false;
+    }
+
+    addEventListener("DOMContentLoaded", function init() {
+        // Intercept clicks to <a> in the document.
+        var links = document.links;
+        var len = links.length;
+
+        for(var i=0; i<len; i++) {
+            links[i].onclick = handleClick;
+        }
+    }, false);
+}());

--- a/src/extensions/default/bramble/lib/PostMessageTransport.js
+++ b/src/extensions/default/bramble/lib/PostMessageTransport.js
@@ -22,6 +22,7 @@ define(function (require, exports, module) {
     var PostMessageTransportRemote = require("text!lib/PostMessageTransportRemote.js");
     var Tutorial = require("lib/Tutorial");
     var ScrollManager = require("lib/ScrollManager");
+    var LinkManager = require("lib/LinkManager");
 
     // An XHR shim will be injected as well to allow XHR to the file system
     var XHRShim = require("text!lib/xhr/XHRShim.js");
@@ -67,7 +68,13 @@ define(function (require, exports, module) {
             return;
         }
 
-        if(msgObj.type === "message"){
+        if(msgObj.type === "message") {
+            // Deal with the case of a user clicking a <a> to navigate to a new file.
+            if(LinkManager.isNavigationRequest(msgObj.message)) {
+                LinkManager.navigate(msgObj.message);
+                return;
+            }
+
             if(msgObj.message) {
                 msgObj.message = resolveLinks(msgObj.message);
             }
@@ -174,7 +181,8 @@ define(function (require, exports, module) {
         return '<base href="' + window.location.href + '">\n' +
             "<script>\n" + PostMessageTransportRemote + "</script>\n" +
             "<script>\n" + XHRShim + "</script>\n" +
-            ScrollManager.getRemoteScript(currentPath);
+            ScrollManager.getRemoteScript(currentPath) +
+            LinkManager.getRemoteScript();
     }
 
     // URL of document being rewritten/launched (if any)

--- a/src/extensions/default/bramble/main.js
+++ b/src/extensions/default/bramble/main.js
@@ -36,24 +36,12 @@ define(function (require, exports, module) {
     ExtensionUtils.loadStyleSheet(module, "stylesheets/sidebarTheme.css");
 
     function parseData(data) {
-        var dataReceived = data;
-
         try {
-            data = dataReceived || null;
-            data = JSON.parse(data);
-            data = data || {};
+            data = JSON.parse(data || null);
+            return data || {};
         } catch(err) {
-            // Quick fix: Ignore the 'process-tick' message being sent
-            if(dataReceived === "process-tick") {
-                return false;
-            }
-
-            console.error("Parsing message from thimble failed: ", err);
-
             return false;
         }
-
-        return data;
     }
 
     function handleMessage(message) {

--- a/src/extensions/default/bramble/nohost/HTMLServer.js
+++ b/src/extensions/default/bramble/nohost/HTMLServer.js
@@ -13,7 +13,8 @@ define(function (require, exports, module) {
         CSSRewriter             = brackets.getModule("filesystem/impls/filer/lib/CSSRewriter");
 
     var Compatibility           = require("lib/compatibility"),
-        ScrollManager           = require("lib/ScrollManager");
+        ScrollManager           = require("lib/ScrollManager"),
+        LinkManager             = require("lib/LinkManager");
 
     var fs = Filer.fs(),
         _shouldUseBlobURL;
@@ -149,7 +150,8 @@ define(function (require, exports, module) {
 
                 // Since we're not instrumenting this doc fully for some reason,
                 // at least inject the scroll manager so we can track scroll position.
-                body = body.replace(/<\/\s*head>/, ScrollManager.getRemoteScript(path) + "$&");
+                body = body.replace(/<\/\s*head>/,
+                    ScrollManager.getRemoteScript(path) + LinkManager.getRemoteScript() + "$&");
                 serve(body);
             });
         }


### PR DESCRIPTION
This makes `<a>` links in the preview window do what you'd expect, specifically:
* relative links to files in the filesystem will cause the preview and editor to try to change to that file.  For the common case this works well (html files).  For scripts, images, etc. it will just load it in the editor.
*  absolute URLs will cause a new window to be opened with that content, leaving the editor/preview as they are