### PR TITLE
Fix https://github.com/mozilla/thimble.webmaker.org/issues/1125

### DIFF
--- a/src/extensions/default/bramble/lib/LinkManager.js
+++ b/src/extensions/default/bramble/lib/LinkManager.js
@@ -7,7 +7,6 @@ define(function (require, exports, module) {
     var Commands            = brackets.getModule("command/Commands");
     var FileSystem          = brackets.getModule("filesystem/FileSystem");
 
-    var Launcher = require("lib/launcher");
     var LinkManagerRemote = require("text!lib/LinkManagerRemote.js");
 
     function getRemoteScript() {
@@ -40,11 +39,7 @@ define(function (require, exports, module) {
         var currentDir = Path.dirname(currentDoc.doc.file.fullPath);
         path = Path.resolve(currentDir, path);
 
-        // Open it in the preview
-        var launcher = Launcher.getCurrentInstance();
-        launcher.launch(path);
-
-        // Open it in the editor
+        // Open it in the editor, which will also attempt to update the preview to match
         FileSystem.resolve(path, function(err, file) {
             if(err) {
                 console.log("[Bramble Error] unable to open path in editor", path, err);


### PR DESCRIPTION
This fixes LinkManager to only open URLs once via file navigation vs. Launcher.launch()