### PR TITLE
Fix https://github.com/mozilla/thimble.webmaker.org/issues/1137

### DIFF
--- a/src/filesystem/impls/filer/lib/HTMLRewriter.js
+++ b/src/filesystem/impls/filer/lib/HTMLRewriter.js
@@ -1,5 +1,5 @@
 /*jslint vars: true, plusplus: true, devel: true, nomen: true, regexp: true, indent: 4, maxerr: 50 */
-/*global define, DOMParser */
+/*global define, DOMParser, XMLSerializer */
 define(function (require, exports, module) {
     "use strict";
 
@@ -184,9 +184,18 @@ define(function (require, exports, module) {
             iterator("styleSheetLinks"),
             iterator("scripts")
         ], function finishedRewriteSeries(err) {
-            // Return the processed HTML
-            var html = rewriter.doc.documentElement.outerHTML;
-            callback(err, html);
+            var doc = rewriter.doc;
+
+            // Get processed DOM as HTML string
+            var html = doc.documentElement.outerHTML;
+
+            // Figure out this document's doctype, if present
+            var doctype = "";
+            if(doc.doctype) {
+                doctype = (new XMLSerializer()).serializeToString(doc.doctype);
+            }
+
+            callback(err, doctype + html);
         });
     }
 


### PR DESCRIPTION
We weren't including the document's `doctype` string in the rewritten HTML we used to generate the Blob URL for the preview iframe.  This caused the browser to switch to quirks mode, and make unexpected rendering choices vs. what happens on publish, where the doctype *was* being included.

This is another version of the bug we he once upon a time where we switched from `innerHTML` to `outerHTML` in order to get attributes on the `<html>` element.  The trick I've used to build the string back from `document.doctype` is going to work in any browser greater than IE9, so we're good.