### PR TITLE
Update gruntfile to automatically copy markdown css to dist/ on build-browser

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -111,6 +111,7 @@ module.exports = function (grunt) {
                             'dependencies.js',
                             'thirdparty/requirejs/require.js',
                             'thirdparty/slowparse/locale/*',
+                            'thirdparty/github-markdown.css',
                             'LiveDevelopment/launch.html',
                             'LiveDevelopment/MultiBrowserImpl/transports/**',
                             'LiveDevelopment/MultiBrowserImpl/launchers/**',


### PR DESCRIPTION
I missed this step doing the markdown transform patch.  The css file I need to use when rendering a markdown file needs to get copied over from `src/` to `dist/` when we build.  This adds that step.