### PR TITLE
Fix font issues related to code folding

### DIFF
--- a/src/extensions/default/bramble/stylesheets/darkTheme.css
+++ b/src/extensions/default/bramble/stylesheets/darkTheme.css
@@ -150,3 +150,7 @@ div.CodeMirror-selected {
   color: #555;
   padding: 0 10px;
 }
+.inline-widget .CodeMirror-gutter.CodeMirror-linenumbers,
+.inline-widget .CodeMirror-gutter.CodeMirror-foldgutter {
+  background-color: #1b1b1b !important;
+}

--- a/src/extensions/default/bramble/stylesheets/lightTheme.css
+++ b/src/extensions/default/bramble/stylesheets/lightTheme.css
@@ -67,6 +67,11 @@ span.cm-variable {
 .CodeMirror-linenumber {
   color: #CCC;
 }
+
+.inline-widget .CodeMirror-gutter.CodeMirror-foldgutter {
+  background-color: #e6e9e9 !important;
+}
+
 .CodeMirror-gutter:after {
   content: "";
   position: absolute;

--- a/src/styles/brackets_fonts.less
+++ b/src/styles/brackets_fonts.less
@@ -18,6 +18,8 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
 // DEALINGS IN THE SOFTWARE.
 
+/* Bramble Font - https://www.google.com/fonts/specimen/Inconsolata */
+@import url(https://fonts.googleapis.com/css?family=Inconsolata);
 
 /* Brackets Fonts */
 

--- a/src/styles/bramble_overrides.css
+++ b/src/styles/bramble_overrides.css
@@ -19,3 +19,9 @@ li.jstree-leaf > a {
 .CodeMirror-sizer {
 	margin-left: 75px !important;
 }
+
+/* Reduce the size of the code-folding gutter markers  with our larger font size */
+.CodeMirror-foldgutter-open:after,
+.CodeMirror-foldgutter-folded:after {
+  font-size: .7em !important;
+}


### PR DESCRIPTION
This fixes a few issues with fonts related to font-folding, and updates/replaces  https://github.com/humphd/brackets/pull/473.  Specifically it used the wrong font, font-size, and also didn't do backgrounds correctly for inline editors.

Before (dark and light themes):

![screenshot 2015-10-08 12 09 43](https://cloud.githubusercontent.com/assets/427398/10372443/c7eb8774-6db5-11e5-97f3-4d7a57b5a3a9.png)

After (dark and light themes):

![screenshot 2015-10-08 12 07 37](https://cloud.githubusercontent.com/assets/427398/10372438/c43c1bca-6db5-11e5-88f2-053c463a0202.png)

The extra font I load adds 9K to the overall loading size, which I think is fine.

r? @flukeout, @gideonthomas 