### PR TITLE
Split filesystem impl, fixes https://github.com/mozilla/thimble.webmaker.org/issues/1150

### DIFF
--- a/src/extensions/default/bramble/main.js
+++ b/src/extensions/default/bramble/main.js
@@ -26,6 +26,7 @@ define(function (require, exports, module) {
         ExtensionUtils       = brackets.getModule("utils/ExtensionUtils"),
         PostMessageTransport = require("lib/PostMessageTransport"),
         Path                 = brackets.getModule("filesystem/impls/filer/BracketsFiler").Path,
+        FileSystemCache      = brackets.getModule("filesystem/impls/filer/FileSystemCache"),
         BlobUtils            = brackets.getModule("filesystem/impls/filer/BlobUtils"),
         XHRHandler           = require("lib/xhr/XHRHandler"),
         Theme                = require("lib/Theme"),
@@ -142,7 +143,7 @@ define(function (require, exports, module) {
 
             deferred.always(function() {
                 // Preload BlobURLs for all assets in the filesystem
-                BlobUtils.preload(root, function(err) {
+                FileSystemCache.refresh(function(err) {
                     if(err) {
                         // Possibly non-critical error, warn at least, but keep going.
                         console.warn("[Bramble] unable to preload all filesystem Blob URLs", err);

--- a/src/filesystem/impls/filer/ArchiveUtils.js
+++ b/src/filesystem/impls/filer/ArchiveUtils.js
@@ -5,17 +5,17 @@
 define(function (require, exports, module) {
     "use strict";
 
-    var CommandManager = require("command/CommandManager");
-    var Commands       = require("command/Commands");
-    var async          = require("filesystem/impls/filer/lib/async");
-    var StartupState   = require("bramble/StartupState");
-    var JSZip          = require("thirdparty/jszip/dist/jszip.min");
-    var BlobUtils      = require("filesystem/impls/filer/BlobUtils");
-    var Filer          = require("filesystem/impls/filer/BracketsFiler");
-    var saveAs         = require("thirdparty/FileSaver");
-    var Buffer         = Filer.Buffer;
-    var Path           = Filer.Path;
-    var fs             = Filer.fs();
+    var CommandManager  = require("command/CommandManager");
+    var Commands        = require("command/Commands");
+    var async           = require("filesystem/impls/filer/lib/async");
+    var StartupState    = require("bramble/StartupState");
+    var JSZip           = require("thirdparty/jszip/dist/jszip.min");
+    var FileSystemCache = require("filesystem/impls/filer/FileSystemCache");
+    var Filer           = require("filesystem/impls/filer/BracketsFiler");
+    var saveAs          = require("thirdparty/FileSaver");
+    var Buffer          = Filer.Buffer;
+    var Path            = Filer.Path;
+    var fs              = Filer.fs();
 
     // Mac and Windows clutter zip files with extra files/folders we don't need
     function _skipFile(filename) {
@@ -53,7 +53,7 @@ define(function (require, exports, module) {
         // Update the file tree to show the new files
         CommandManager.execute(Commands.FILE_REFRESH).always(function() {
             // Generate Blob URLs for all the files we imported
-            BlobUtils.preload(StartupState.project("root"), callback);
+            FileSystemCache.refresh(callback);
         });
     }
 

--- a/src/filesystem/impls/filer/BlobUtils.js
+++ b/src/filesystem/impls/filer/BlobUtils.js
@@ -6,13 +6,9 @@ define(function (require, exports, module) {
 
     // BlobUtils provides an opportunistic cache for BLOB Object URLs
     // which can be looked-up synchronously.
-    var Content = require("filesystem/impls/filer/lib/content");
     var FilerUtils = require("filesystem/impls/filer/FilerUtils");
-    var async = require("filesystem/impls/filer/lib/async");
-    var Transforms = require("filesystem/impls/filer/lib/transforms");
     var Path = FilerUtils.Path;
     var decodePath = FilerUtils.decodePath;
-    var fs = require("filesystem/impls/filer/BracketsFiler").fs();
 
     // 2-way cache for blob URL to path for looking up either way:
     // * paths - paths keyed on blobUrls
@@ -65,45 +61,14 @@ define(function (require, exports, module) {
         delete blobURLs[oldPath];
     }
 
-    // Given a filename, lookup the cached BLOB URL
-    function _getUrlSync(filename) {
+    // NOTE: make sure that we always return the filename unchanged if we
+    // don't have a cached URL.  Don't return a normalized, decoded version.
+    function getUrl(filename) {
         var url = blobURLs[Path.normalize(decodePath(filename))];
 
         // We expect this to exist, if it doesn't,
         // return path back unchanged
         return url || filename;
-    }
-
-    function _getUrlAsync(filename, callback) {
-        var decodedFilename = decodePath(filename);
-        var cachedUrl = blobURLs[Path.normalize(decodedFilename)];
-        if(cachedUrl) {
-            callback(null, cachedUrl);
-            return;
-        }
-
-        fs.readFile(decodedFilename, null, function(err, data) {
-            if(err) {
-                callback(err);
-                return;
-            }
-
-            var mime = Content.mimeFromExt(Path.extname(decodedFilename));
-            var url = createURL(decodedFilename, data, mime);
-            callback(null, url);
-        });        
-    }
-
-    // Support sync and async calls to the URL cache. Also check to see
-    // if async calls can by run immediately regardless (i.e., no disk access).
-    // NOTE: make sure that we always return the filename unchanged if we
-    // don't have a cached URL.  Don't return a normalized, decoded version.
-    function getUrl(filename, maybeCallback) {
-        if(typeof maybeCallback === "function") {
-            _getUrlAsync(filename, maybeCallback);
-        } else {
-            return _getUrlSync(filename);
-        }
     }
 
     // Given a BLOB URL, lookup the associated filename
@@ -129,45 +94,6 @@ define(function (require, exports, module) {
         return url;
     }
 
-    // Walk the project root dir and make sure we have Blob URLs generated for all file paths
-    function preload(root, callback) {
-        function _preload(dirPath, callback) {
-            fs.readdir(dirPath, function(err, entries) {
-                if(err) {
-                    return callback(err);
-                }
-
-                function _getBlobUrl(name, callback) {
-                    name = Path.join(dirPath, name);
-
-                    fs.stat(name, function(err, stats) {
-                        if(err) {
-                            return callback(err);
-                        }
-
-                        if(stats.type === 'DIRECTORY') {
-                            _preload(name, callback);
-                        } else {
-                            // If there's a transform needed for this file, do that first.
-                            Transforms.applyTransform(name, function(err) {
-                                if(err) {
-                                    return callback(err);
-                                }
-
-                                getUrl(name, callback);
-                            });
-                        }
-                    });
-                }
-
-                async.eachSeries(entries, _getBlobUrl, callback);
-            });
-        }
-
-        _preload(root, callback);
-    }
-
-    exports.preload = preload;
     exports.remove = remove;
     exports.rename = rename;
     exports.getUrl = getUrl;

--- a/src/filesystem/impls/filer/BracketsFiler.js
+++ b/src/filesystem/impls/filer/BracketsFiler.js
@@ -7,18 +7,23 @@ define(function (require, exports, module) {
     var FilerUtils = require("filesystem/impls/filer/FilerUtils");
     var Path = FilerUtils.Path;
     var FilerBuffer = FilerUtils.Buffer;
+    var decodePath = require("filesystem/impls/filer/FilerUtils").decodePath;
 
     var proxyFS = {
         stat: function(path, callback) {
+            path = decodePath(path);
             proxyCall("stat", {args: [path]}, callback);
         },
         exists: function(path, callback) {
+            path = decodePath(path);
             proxyCall("exists", {args: [path]}, callback);
         },
         readdir: function(path, callback) {
+            path = decodePath(path);
             proxyCall("readdir", {args: [path]}, callback);
         },
         mkdir: function(path, callback) {
+            path = decodePath(path);
             proxyCall("mkdir", {args: [path]}, callback);
         },
         /**
@@ -27,6 +32,7 @@ define(function (require, exports, module) {
          * https://github.com/filerjs/filer/blob/develop/src/shell/shell.js
          */
         mkdirp: function(path, callback) {
+            path = decodePath(path);
             callback = callback || function(){};
 
             // We don't have direct access to Filer.Errors, fake it.
@@ -86,15 +92,21 @@ define(function (require, exports, module) {
             _mkdirp(path, callback);
         },
         rmdir: function(path, callback) {
+            path = decodePath(path);
             proxyCall("rmdir", {args: [path]}, callback);
         },
         unlink: function(path, callback) {
+            path = decodePath(path);
             proxyCall("unlink", {args: [path]}, callback);
         },
         rename: function(oldPath, newPath, callback) {
+            oldPath = decodePath(oldPath);
+            newPath = decodePath(newPath);
             proxyCall("rename", {args: [oldPath, newPath]}, callback);
         },
         readFile: function(path, options, callback) {
+            path = decodePath(path);
+
             if(typeof options === "function") {
                 callback = options;
                 options = {};
@@ -139,6 +151,7 @@ define(function (require, exports, module) {
             proxyCall("writeFile", options, callback);
         },
         watch: function(path, options, callback) {
+            path = decodePath(path);
             proxyCall("watch", {args: [path, options], persist: true}, callback);
         }
     };

--- a/src/filesystem/impls/filer/FileSystemCache.js
+++ b/src/filesystem/impls/filer/FileSystemCache.js
@@ -1,0 +1,81 @@
+/*jslint vars: true, plusplus: true, devel: true, nomen: true, regexp: true, indent: 4, maxerr: 50 */
+/*global define */
+
+define(function (require, exports, module) {
+    "use strict";
+
+    var Content = require("filesystem/impls/filer/lib/content");
+    var async = require("filesystem/impls/filer/lib/async");
+    var BracketsFiler = require("filesystem/impls/filer/BracketsFiler");
+    var BlobUtils = require("filesystem/impls/filer/BlobUtils");
+    var Path = BracketsFiler.Path;
+    var Transforms = require("filesystem/impls/filer/lib/transforms");
+    var StartupState = require("bramble/StartupState");
+    var decodePath = require("filesystem/impls/filer/FilerUtils").decodePath;
+
+    // Walk the project root dir and make sure we have Blob URLs generated for
+    // all file paths.
+    exports.refresh = function(callback) {
+        var fs = BracketsFiler.fs();
+
+        function _getUrlAsync(filename, callback) {
+            var decodedFilename = decodePath(filename);
+            var cachedUrl = BlobUtils.getUrl(filename);
+
+            // If we get a Blob URL (i.e., not the filename back) and get it
+            // synchronously, run the callback and yield to main thread.
+            if(cachedUrl !== filename) {
+                setTimeout(function() {
+                    callback(null, cachedUrl);
+                }, 0);
+                return;
+            }
+
+            fs.readFile(decodedFilename, null, function(err, data) {
+                if(err) {
+                    callback(err);
+                    return;
+                }
+
+                var mime = Content.mimeFromExt(Path.extname(decodedFilename));
+                var url = BlobUtils.createURL(filename, data, mime);
+                callback(null, url);
+            });
+        }
+
+        function _load(dirPath, callback) {
+            fs.readdir(dirPath, function(err, entries) {
+                if(err) {
+                    return callback(err);
+                }
+
+                function _getBlobUrl(name, callback) {
+                    name = Path.join(dirPath, name);
+
+                    fs.stat(name, function(err, stats) {
+                        if(err) {
+                            return callback(err);
+                        }
+
+                        if(stats.type === 'DIRECTORY') {
+                            _load(name, callback);
+                        } else {
+                            // If there's a transform needed for this file, do that first.
+                            Transforms.applyTransform(name, function(err) {
+                                if(err) {
+                                    return callback(err);
+                                }
+
+                                _getUrlAsync(name, callback);
+                            });
+                        }
+                    });
+                }
+
+                async.eachSeries(entries, _getBlobUrl, callback);
+            });
+        }
+
+        _load(StartupState.project("root"), callback);
+    };
+});


### PR DESCRIPTION
This was an attempt to move all the Blob URL caching into `BracketsFiler`, but it turns out to be impossible.  I've made a bunch of good changes though, so I want to take the rest of it.  A few of the things you'll find in it:
* separation of Blob URL preloading into its own module (`FileSystemCache`)
* removal of async versions of URL lookup
* decoding of paths if you use `BracketsFiler` directly vs. via Brackets API
* optional file consistency check on writes, so we don't hit https://github.com/mozilla/thimble.webmaker.org/issues/1150
* I've made the rewriters to be properly async with `setTimeout` to yield control to the main thread more often.  Since almost none of the code is async, a really big web page could block the main thread for a long time.  This will do it in chunks.