### PR TITLE
Fix https://github.com/mozilla/thimble.webmaker.org/issues/1169

### DIFF
--- a/src/styles/bramble_overrides.css
+++ b/src/styles/bramble_overrides.css
@@ -15,11 +15,6 @@ li.jstree-leaf > a {
 	cursor: pointer !important;
 }
 
-/* Add extra space to the left of the cursor in order that it will show at pos 0 */
-.CodeMirror-sizer {
-	margin-left: 75px !important;
-}
-
 /* Reduce the size of the code-folding gutter markers  with our larger font size */
 .CodeMirror-foldgutter-open:after,
 .CodeMirror-foldgutter-folded:after {


### PR DESCRIPTION
This removes the "fix" I did to add spacing to the left of column 0 so you can see the cursor.  I *think* that adding the code folding has improved this such that it's not needed anymore.  Regardless, what I did doesn't work at all font sizes.

r? @flukeout, @gideonthomas 