### PR TITLE
Fix https://github.com/mozilla/thimble.webmaker.org/issues/1182 - allow javascript: and other common non-http schemes

### DIFF
--- a/src/extensions/default/bramble/lib/LinkManagerRemote.js
+++ b/src/extensions/default/bramble/lib/LinkManagerRemote.js
@@ -6,7 +6,13 @@
     function handleClick(e) {
         var url = e.target.getAttribute("href");
 
-        // For local paths vs. absolute URLs, try to open the right file
+        // For local paths vs. absolute URLs, try to open the right file.
+        // Special case (i.e., pass through) some common, non-http(s) protocol
+        // schemes so they work as expected.
+        if(/^(javascript|mailto|data|blob):/.test(url)) {
+            return true;
+        }
+
         if(!(/\:?\/\//.test(url)) && window._Brackets_LiveDev_Transport) {
             window._Brackets_LiveDev_Transport.send("bramble-navigate:" + url);
         } else {


### PR DESCRIPTION
This allows things like the following to work:

```html
<a href="javascript:alert('Here is the alert!');">An alert should pop up from this link.</a>
<a href="mailto:someone@example.com">An email should get created.</a>
```

First reported in https://github.com/mozilla/thimble.webmaker.org/issues/1182