### PR TITLE
Use proper FS abstraction when doing bramble.addNewFile() for Blob URL caching

### DIFF
--- a/README.md
+++ b/README.md
@@ -343,7 +343,7 @@ to be notified when the action completes:
 * `showTutorial([callback])` - shows tutorial (i.e., tutorial.html) vs editor contents in preview
 * `hideTutorial([callback])` - stops showing tutorial (i.e., tutorial.html) and uses editor contents in preview
 * `showUploadFilesDialog([callback])` - shows the Upload Files dialog, allowing users to drag-and-drop, upload a file, or take a selfie.
-* `addNewFile([options, callback])` - adds a new file, using the provided options, which can include: `filename` a `String` with the complete filename to use; `contents` a `Filer.Buffer` or `String` with the new file's data; `ext` a `String` with the new file's extension; `basenamePrefix` a `String` with the basename to use when generating a new filename.  NOTE: if you provide `filename`, `basenamePrefix` and `ext` are ignored.
+* `addNewFile([options, callback])` - adds a new text file, using the provided options, which can include: `filename` a `String` with the complete filename to use; `contents` a `String` with the new text file's data; `ext` a `String` with the new file's extension; `basenamePrefix` a `String` with the basename to use when generating a new filename.  NOTE: if you provide `filename`, `basenamePrefix` and `ext` are ignored.
 * `addNewFolder([callback])` - adds a new folder.
 * `export([callback])` - creates an archive `.zip` file of the entire project's filesystem, and downloads it to the browser.
 

--- a/src/bramble/client/main.js
+++ b/src/bramble/client/main.js
@@ -835,13 +835,11 @@ define([
     };
 
     BrambleProxy.prototype.addNewFile = function(options, callback) {
-        // Always use a buffer if we send contents
-        if(typeof(options.contents) === "string") {
-            options.contents = new FilerBuffer(options.contents, "utf8");
+        // We only support writing textual data this way
+        if(typeof(options.contents) !== "string") {
+            callback(new Error("expected string for file contents"));
+            return;
         }
-
-        // Serialize buffer to a regular array
-        options.contents = options.contents.toJSON().data;
 
         this._executeRemoteCommand({
             commandCategory: "bramble",


### PR DESCRIPTION
This switches the `bramble.addNewFile()` API to use the right fs abstraction, such that files get automatically cached in the Blob URL cache.  I've also changed things to only support writing text files this way, which makes things a lot easier, in terms of re-using internal API calls.

NOTE: if you test this locally, you'll need to run `grunt build-browser` to get the client API changes rebuilt. 