### PR TITLE
Fix https://github.com/mozilla/thimble.webmaker.org/issues/945 - reduce line number gutter width

### DIFF
--- a/src/styles/brackets_codemirror_override.less
+++ b/src/styles/brackets_codemirror_override.less
@@ -170,7 +170,9 @@ div.CodeMirror-cursors {
 
 .CodeMirror-linenumber {
     color: @accent-comment;
+/* XXXBramble: Brackets does this, but we don't need that much extra width
     min-width: 2.5em;
+*/
     /*font-size: 0.9em;*/  /* restore after SourceCodePro font fix? */
     padding: 0 @code-padding 0 10px;  // note: overridden if code-folding gutter is shown
 }


### PR DESCRIPTION
Top is with this patch, bottom is what we do now:

![screenshot 2015-11-06 13 40 17](https://cloud.githubusercontent.com/assets/427398/11005570/6b2f336c-848c-11e5-841f-925229e9ed3a.png)

r? @gideonthomas 