### PR TITLE
Don't let requirejs timeout loading over slow networks, part of https://github.com/mozilla/thimble.webmaker.org/issues/1224

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -204,6 +204,8 @@ module.exports = function (grunt) {
             dist: {
                 // Options: https://github.com/jrburke/r.js/blob/master/build/example.build.js
                 options: {
+                    // Disable module loading timeouts, due to the size of what we load
+                    waitSeconds: 0,
                     // `name` and `out` is set by grunt-usemin
                     baseUrl: 'src',
                     optimize: 'uglify2',

--- a/src/extensions/default/JavaScriptCodeHints/tern-worker.js
+++ b/src/extensions/default/JavaScriptCodeHints/tern-worker.js
@@ -36,7 +36,10 @@ var config = {};
     require(["./MessageIds", "./HintUtils2"], function (messageIds, hintUtils2) {
         MessageIds = messageIds;
         HintUtils2 = hintUtils2;
-        var ternRequire = require.config({baseUrl: "./thirdparty"});
+        var ternRequire = require.config({
+            waitSeconds: 120,
+            baseUrl: "./thirdparty"
+        });
         ternRequire(["tern/lib/tern", "tern/lib/infer"], function (tern, infer) {
             Tern = tern;
             Infer = infer;

--- a/src/extensions/extra/HTMLHinter/main.js
+++ b/src/extensions/extra/HTMLHinter/main.js
@@ -2,6 +2,7 @@
 /*global define, brackets*/
 
 require.config({
+    waitSeconds: 120,
     paths: {
         "text" : "lib/text",
         "i18n" : "lib/i18n"

--- a/src/main.js
+++ b/src/main.js
@@ -29,6 +29,8 @@
  * configuration and loads the brackets module.
  */
 require.config({
+    // Disable module loading timeouts, due to the size of what we load
+    waitSeconds: 0,
     paths: {
         "text"              : "thirdparty/text/text",
         "i18n"              : "thirdparty/i18n/i18n",

--- a/src/utils/ExtensionLoader.js
+++ b/src/utils/ExtensionLoader.js
@@ -159,6 +159,8 @@ define(function (require, exports, module) {
      */
     function loadExtensionModule(name, config, entryPoint) {
         var extensionConfig = {
+            // Disable module loading timeouts, due to the size of what we load
+            waitSeconds: 0,
             context: name,
             baseUrl: config.baseUrl,
             /* FIXME (issue #1087): can we pass this from the global require context instead of hardcoding twice? */


### PR DESCRIPTION
This alters requirejs' default timeout for module loading, disabling it for the major sections of the code (all core and extension configs), and bumping internal uses to 120s (I think it's OK for these to timeout eventually, since the whole app is loaded already).

With this change, I'm able to load the editor over a 2G connection. 