### PR TITLE
Fix https://github.com/mozilla/thimble.webmaker.org/issues/1269

### DIFF
--- a/src/extensions/default/bramble/lib/UI.js
+++ b/src/extensions/default/bramble/lib/UI.js
@@ -201,6 +201,7 @@ define(function (require, exports, module) {
 
     function disableFullscreenPreview() {
         $("#main-view").removeClass("fullscreen-preview");
+        MainViewManager.setActivePaneId("first-pane");
     }
 
     function showDesktopView(preventReload) {

--- a/src/styles/bramble_overrides.css
+++ b/src/styles/bramble_overrides.css
@@ -64,10 +64,11 @@ li.jstree-leaf > a {
     height: auto !important;
 }
 
-.fullscreen-preview  #first-pane {
-    display: none;
+
+.fullscreen-preview #first-pane {
+    width: 0 !important;
 }
 
-.fullscreen-preview  .main-view .content {
-  left: 0 !important;
+.fullscreen-preview .main-view .content {
+    left: 0 !important;
 }


### PR DESCRIPTION
CodeMirror doesn't seem to like having `display:none` applied, but with this it *seems* to work.  See if you can break it.