### PR TITLE
Fix #510 - Shutdown camera after taking a selfie

### DIFF
--- a/src/extensions/default/BrambleUrlCodeHints/camera/video.js
+++ b/src/extensions/default/BrambleUrlCodeHints/camera/video.js
@@ -69,7 +69,10 @@ define(function (require, exports, module) {
         vendorURL.revokeObjectURL(this.interface.src);
 
         if(this.stream) {
-            this.stream.stop();
+            var video = this.stream.getVideoTracks ? this.stream.getVideoTracks()[0] : null;
+            if(video) {
+                video.stop();
+            }
             this.stream = null;
             this.streaming = false;
         }


### PR DESCRIPTION
For now, I think we should stick to this fix and we can change the rest of the code to use `mediaDevices.getUserMedia` later on once the MediaStreaming API stabilizes.

One thing that I'm waiting on before we can move forward with this is to test it on older versions of Chrome and Firefox. Just waiting on acquiring the resources to do so.