### PR TITLE
Allow link navigation in tutorials

### DIFF
--- a/src/extensions/default/bramble/lib/LinkManagerRemote.js
+++ b/src/extensions/default/bramble/lib/LinkManagerRemote.js
@@ -4,7 +4,10 @@
     "use strict";
 
     function handleClick(e) {
-        var url = e.target.getAttribute("href");
+        var anchor = e.currentTarget;
+        var url = anchor.href;
+        var href = anchor.getAttribute("href");
+        var element;
 
         // For local paths vs. absolute URLs, try to open the right file.
         // Special case (i.e., pass through) some common, non-http(s) protocol
@@ -13,8 +16,19 @@
             return true;
         }
 
-        if(!(/\:?\/\//.test(url)) && window._Brackets_LiveDev_Transport) {
+        var pathNav = !(/\:?\/\//.test(url));
+        // `fragmentId` handles the special case of fragment ids in the
+        // same html page in preview mode (not tutorial mode)
+        var fragmentId = /^\s*#/.test(href);
+
+        if(pathNav && window._Brackets_LiveDev_Transport) {
             window._Brackets_LiveDev_Transport.send("bramble-navigate:" + url);
+        } else if(fragmentId) {
+            element = document.querySelector(href) || document.getElementsByName(href.slice(1));
+            if(element) {
+                element = element[0] || element;
+                element.scrollIntoView(true);
+            }
         } else {
             window.open(url, "_blank");
         }

--- a/src/extensions/default/bramble/nohost/HTMLServer.js
+++ b/src/extensions/default/bramble/nohost/HTMLServer.js
@@ -13,8 +13,9 @@ define(function (require, exports, module) {
         CSSRewriter             = brackets.getModule("filesystem/impls/filer/lib/CSSRewriter");
 
     var Compatibility           = require("lib/compatibility"),
-        MouseManager           = require("lib/MouseManager"),
-        LinkManager             = require("lib/LinkManager");
+        MouseManager            = require("lib/MouseManager"),
+        LinkManager             = require("lib/LinkManager"),
+        Tutorial                = require("lib/Tutorial");
 
     var fs = Filer.fs(),
         _shouldUseBlobURL;
@@ -151,7 +152,8 @@ define(function (require, exports, module) {
                 // Since we're not instrumenting this doc fully for some reason,
                 // at least inject the scroll manager so we can track scroll position.
                 body = body.replace(/<\/\s*head>/,
-                    MouseManager.getRemoteScript(path) + LinkManager.getRemoteScript() + "$&");
+                    (Tutorial.getOverride() ? "" : MouseManager.getRemoteScript(path)) +
+                    LinkManager.getRemoteScript() + "$&");
                 serve(body);
             });
         }


### PR DESCRIPTION
mozilla/thimble.webmaker.org#1277

This won't work until we figure out how to handle the injection of the `<base>` tag into the preview iframe which changes the base url for all relative paths inside the iframe to the thimble url and screws things up