### PR TITLE
Removed box shadow from the arrow element.

### DIFF
--- a/src/styles/bramble_popover.less
+++ b/src/styles/bramble_popover.less
@@ -104,7 +104,6 @@
     border-top: 10px solid @dark-bc-panel-bg;
     border-left: 5px solid transparent;
     border-right: 5px solid transparent;
-    box-shadow: 0px 1px 0 rgba(0, 0, 0, 0.18);
 
     .dark & {
       border-top: 10px solid white;
@@ -116,7 +115,6 @@
 }
 
 #popover-container.bubble-below:before {
-    box-shadow: 0px 1px 0 rgba(255, 255, 255, 0.18);
     transform: rotate(180deg);
     top: -9px;
 }


### PR DESCRIPTION
Removes the little underline under the arrow element, as seen in [this comment](https://github.com/mozilla/brackets/pull/826#issuecomment-321074890).